### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/instance/layout.tsx
+++ b/app/(main)/instance/layout.tsx
@@ -12,7 +12,6 @@ import {
   SquareIcon,
   RotateCcwIcon,
   SnowflakeIcon,
-  ServerIcon,
 } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger } from 'ui-web/components/tabs';
 import { OSLogo } from '@/app/_components/OSLogo';


### PR DESCRIPTION
To fix the problem, remove only the `ServerIcon` symbol from the destructuring import statement from `'lucide-react'`. This will eliminate the unused import and clean up the code without affecting any in-use functionality. No other changes, imports, or additions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._