### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/_components/devices.tsx
+++ b/app/(main)/_components/devices.tsx
@@ -1475,7 +1475,7 @@ function AddDeviceForm({
     const isBool = config.type === 'bool';
     const hasCondition =
       config.condition && typeof config.condition === 'string';
-    const hasError = !!fieldErrors[fieldKey];
+    
     const errorId = `${fieldId}-error`;
 
     // Check if field should be shown using centralized logic


### PR DESCRIPTION
To fix the issue, simply remove the line that declares and assigns `hasError` in the `renderField` function within app/(main)/_components/devices.tsx. Make sure not to remove any context or lines that would affect adjacent logic. This is a straightforward change and requires no additional imports, definitions, or code updates elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._