### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/_components/devices.tsx
+++ b/app/(main)/_components/devices.tsx
@@ -1476,7 +1476,7 @@ function AddDeviceForm({
     const hasCondition =
       config.condition && typeof config.condition === 'string';
     const hasError = !!fieldErrors[fieldKey];
-    const errorId = `${fieldId}-error`;
+    // errorId removed (unused variable)
 
     // Check if field should be shown using centralized logic
     if (!shouldShowField(fieldKey, config)) {


### PR DESCRIPTION
To fix this problem, the unused variable `errorId` should be removed from the `renderField` function. This involves simply deleting its definition (i.e., removing `const errorId = ...`) on line 1479. No changes to other code should be made unless any following new usages of `errorId` are identified, which seems unlikely given the provided code. The removal will tidy up the code and silence the warning from CodeQL regarding an unused variable.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._