### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/_components/devices.tsx
+++ b/app/(main)/_components/devices.tsx
@@ -2044,7 +2044,6 @@ export default function Devices({
     device: Device;
   } | null>(null);
   const [isCreatingRootDisk, setIsCreatingRootDisk] = React.useState(false);
-  const { isMobile } = useMobile();
 
   const { data: configurableOptions } = useConfigurableOptions();
   const isInternalUpdate = React.useRef(false);


### PR DESCRIPTION
The best fix is to remove the `isMobile` destructuring from the result of the `useMobile()` hook on line 2047, as well as the call to `useMobile()` itself, since its result is not used.  
- Directly edit line 2047 in the `Devices` component.
- Remove the destructuring assignment for `isMobile` and, if no other variables are destructured, remove the entire statement.
- No imports, definitions, or further changes are needed, since the variable is not used anywhere else.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._