### PR TITLE
feat: Add operations layout, refactor site header for dynamic breadcr…

### DIFF
--- a/app/(main)/_components/header.tsx
+++ b/app/(main)/_components/header.tsx
@@ -15,7 +15,7 @@ import {
 import { use } from 'react';
 import ProjectsContext from '@/app/(main)/_context/projects';
 
-export function SiteHeader() {
+export function SiteHeader({ children }: { children?: React.ReactNode }) {
   const { projects, currentProject, setProject, isLoading } =
     use(ProjectsContext);
   return (
@@ -27,7 +27,7 @@ export function SiteHeader() {
           className="mx-2 data-[orientation=vertical]:h-4"
         />
 
-        <h1 className="text-base font-medium">Instances</h1>
+        {children}
         <Select
           value={currentProject}
           onValueChange={setProject}
@@ -48,10 +48,10 @@ export function SiteHeader() {
               <SelectLabel>Projects</SelectLabel>
               {!isLoading
                 ? projects.map((project) => (
-                    <SelectItem key={project.name} value={project.name}>
-                      {project.name}
-                    </SelectItem>
-                  ))
+                  <SelectItem key={project.name} value={project.name}>
+                    {project.name}
+                  </SelectItem>
+                ))
                 : null}
             </SelectGroup>
           </SelectContent>

--- a/app/(main)/instance/layout.tsx
+++ b/app/(main)/instance/layout.tsx
@@ -32,7 +32,8 @@ function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
   const { name, instance, isLoading, isError, mutate } = useInstanceContext();
 
   const pathname = usePathname();
-  const currentTab = pathname === '/instance' ? 'Dashboard' : (pathname.split('/').pop() || 'Dashboard');
+  const segments = pathname.split('/').filter(Boolean);
+  const currentTab = segments.length > 1 ? segments[1] : 'Dashboard';
   const formattedTab = currentTab.charAt(0).toUpperCase() + currentTab.slice(1);
 
   const renderContent = () => {

--- a/app/(main)/instance/layout.tsx
+++ b/app/(main)/instance/layout.tsx
@@ -17,49 +17,100 @@ import { Tabs, TabsList, TabsTrigger } from 'ui-web/components/tabs';
 import { OSLogo } from '@/app/_components/OSLogo';
 import { getBaseImage } from './_lib/utils';
 import { performInstanceAction, type InstanceAction } from './_lib/instance';
+import { SiteHeader } from '@/app/(main)/_components/header';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from 'ui-web/components/breadcrumb';
+import Link from 'next/link';
 
 function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
   const { name, instance, isLoading, isError, mutate } = useInstanceContext();
 
-  if (!name) {
-    return (
-      <Alert variant="destructive">
-        <AlertTitle>Missing Parameter</AlertTitle>
-        <AlertDescription>
-          The "name" query parameter is required.
-        </AlertDescription>
-      </Alert>
-    );
-  }
+  const pathname = usePathname();
+  const currentTab = pathname === '/instance' ? 'Dashboard' : (pathname.split('/').pop() || 'Dashboard');
+  const formattedTab = currentTab.charAt(0).toUpperCase() + currentTab.slice(1);
 
-  if (isLoading && !instance) {
+  const renderContent = () => {
+    if (!name) {
+      return (
+        <div className="p-6">
+          <Alert variant="destructive">
+            <AlertTitle>Missing Parameter</AlertTitle>
+            <AlertDescription>
+              The "name" query parameter is required.
+            </AlertDescription>
+          </Alert>
+        </div>
+      );
+    }
+
+    if (isLoading && !instance) {
+      return (
+        <div className="flex h-full items-center justify-center p-8">
+          <Spinner className="size-8" />
+        </div>
+      );
+    }
+
+    if (isError || !instance) {
+      return (
+        <div className="p-6">
+          <Alert variant="destructive">
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>
+              {isError?.message || 'Instance not found.'}
+            </AlertDescription>
+          </Alert>
+        </div>
+      );
+    }
+
     return (
-      <div className="flex h-full items-center justify-center p-8">
-        <Spinner className="size-8" />
+      <div className="flex flex-col gap-6 p-6">
+        <InstanceHeader instance={instance} onMutate={mutate} />
+
+        <div className="flex flex-col gap-4">
+          <InstanceTabs />
+          <div className="mt-4">{children}</div>
+        </div>
       </div>
     );
-  }
-
-  if (isError || !instance) {
-    return (
-      <Alert variant="destructive">
-        <AlertTitle>Error</AlertTitle>
-        <AlertDescription>
-          {isError?.message || 'Instance not found.'}
-        </AlertDescription>
-      </Alert>
-    );
-  }
+  };
 
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <InstanceHeader instance={instance} onMutate={mutate} />
-
-      <div className="flex flex-col gap-4">
-        <InstanceTabs />
-        <div className="mt-4">{children}</div>
-      </div>
-    </div>
+    <>
+      <SiteHeader>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link href="/instances">Instances</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            {name && (
+              <>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbLink asChild>
+                    <Link href={`/instance?name=${name}`}>{name}</Link>
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbPage>{formattedTab}</BreadcrumbPage>
+                </BreadcrumbItem>
+              </>
+            )}
+          </BreadcrumbList>
+        </Breadcrumb>
+      </SiteHeader>
+      {renderContent()}
+    </>
   );
 }
 

--- a/app/(main)/instances/layout.tsx
+++ b/app/(main)/instances/layout.tsx
@@ -1,7 +1,30 @@
+import { SiteHeader } from '@/app/(main)/_components/header';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+} from 'ui-web/components/breadcrumb';
+
 export default function InstancesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return (
+    <>
+      <SiteHeader>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbPage>Instances</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </SiteHeader>
+      <div className="p-4 lg:px-6">
+        {children}
+      </div>
+    </>
+  );
 }

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -26,10 +26,8 @@ export default function DashboardLayout({
           <>
             <div className="w-full h-full">
               <div className="flex flex-1 flex-col">
-                <SiteHeader />
-
                 <div className="@container/main flex flex-1 flex-col gap-2">
-                  <div className="p-4  lg:px-6">{children}</div>
+                  {children}
                 </div>
               </div>
             </div>
@@ -37,8 +35,7 @@ export default function DashboardLayout({
         ) : (
           <SidebarInset>
             <ProjectsProvider>
-              <SiteHeader />
-              <div className="p-4  lg:px-6">{children}</div>
+              {children}
             </ProjectsProvider>
           </SidebarInset>
         )}

--- a/app/(main)/operations/layout.tsx
+++ b/app/(main)/operations/layout.tsx
@@ -1,0 +1,30 @@
+import { SiteHeader } from '@/app/(main)/_components/header';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbList,
+    BreadcrumbPage,
+} from 'ui-web/components/breadcrumb';
+
+export default function OperationsLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <>
+            <SiteHeader>
+                <Breadcrumb>
+                    <BreadcrumbList>
+                        <BreadcrumbItem>
+                            <BreadcrumbPage>Operations</BreadcrumbPage>
+                        </BreadcrumbItem>
+                    </BreadcrumbList>
+                </Breadcrumb>
+            </SiteHeader>
+            <div className="p-4 lg:px-6">
+                {children}
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
feat: implement dynamic breadcrumbs in header

- Refactor [SiteHeader](cci:1://file:///root/ararat-web/app/%28main%29/_components/header.tsx:17:0-61:1) to accept children for custom breadcrumb rendering
- Remove [SiteHeader](cci:1://file:///root/ararat-web/app/%28main%29/_components/header.tsx:17:0-61:1) from global [DashboardLayout](cci:1://file:///root/ararat-web/app/%28main%29/layout.tsx:6:0-44:1) to allow per-route customization
- Implement breadcrumbs for:
  - Instances list ([Instances](cci:1://file:///root/ararat-web/app/%28main%29/instances/layout.tsx:8:0-29:1))
  - Instance details (`Instances -> {name} -> {page}`)
  - Operations list (`Operations`)
- Ensure proper padding and layout structure across all affected pages

Closes [#66](https://github.com/hyecompany/ararat-web-incus/issues/66)