### PR TITLE
feat: Add status-based filtering for instance mass actions

### DIFF
--- a/app/(main)/instances/page.tsx
+++ b/app/(main)/instances/page.tsx
@@ -105,6 +105,22 @@ async function performInstanceAction({
   }
 }
 
+function canPerformAction(action: InstanceAction, instance: Instance): boolean {
+  const status = instance.status?.toLowerCase();
+  switch (action) {
+    case 'start':
+      return status === 'stopped';
+    case 'stop':
+      return status === 'running' || status === 'frozen';
+    case 'restart':
+      return status === 'running';
+    case 'freeze':
+      return status === 'running';
+    default:
+      return false;
+  }
+}
+
 export default function Instances() {
   const { currentProject } = use(ProjectsContext);
   const { data, error, isLoading, isValidating, mutate } =
@@ -244,12 +260,16 @@ export default function Instances() {
 
   const handleMassAction = React.useCallback(
     async (action: InstanceAction) => {
-      if (!selectedInstances.length) return;
+      const targetInstances = selectedInstances.filter((instance) =>
+        canPerformAction(action, instance),
+      );
+
+      if (!targetInstances.length) return;
       try {
         setActionError(null);
         setActionInFlight(action);
         await Promise.all(
-          selectedInstances.map((instance) =>
+          targetInstances.map((instance) =>
             performInstanceAction({
               action,
               instance,
@@ -395,22 +415,28 @@ export default function Instances() {
                       Icon: React.ComponentType<{ className?: string }>;
                     },
                   ][]
-                ).map(([action, { label, Icon }]) => (
-                  <Button
-                    key={action}
-                    variant="outline"
-                    size="sm"
-                    disabled={actionInFlight !== null || deleteInFlight}
-                    onClick={() => handleMassAction(action)}
-                  >
-                    {actionInFlight === action ? (
-                      <Spinner className="mr-2 size-3" />
-                    ) : (
-                      <Icon className="mr-2 size-3" />
-                    )}
-                    {label}
-                  </Button>
-                ))}
+                )
+                  .filter(([action]) =>
+                    selectedInstances.some((instance) =>
+                      canPerformAction(action, instance),
+                    ),
+                  )
+                  .map(([action, { label, Icon }]) => (
+                    <Button
+                      key={action}
+                      variant="outline"
+                      size="sm"
+                      disabled={actionInFlight !== null || deleteInFlight}
+                      onClick={() => handleMassAction(action)}
+                    >
+                      {actionInFlight === action ? (
+                        <Spinner className="mr-2 size-3" />
+                      ) : (
+                        <Icon className="mr-2 size-3" />
+                      )}
+                      {label}
+                    </Button>
+                  ))}
                 {deletableInstances.length > 0 && (
                   <Button
                     variant="destructive"

--- a/app/(main)/instances/page.tsx
+++ b/app/(main)/instances/page.tsx
@@ -111,7 +111,7 @@ function canPerformAction(action: InstanceAction, instance: Instance): boolean {
     case 'start':
       return status === 'stopped';
     case 'stop':
-      return status === 'running' || status === 'frozen';
+      return status === 'running' || status === 'started' || status === 'frozen';
     case 'restart':
       return status === 'running' || status === 'started';
     case 'freeze':

--- a/app/(main)/instances/page.tsx
+++ b/app/(main)/instances/page.tsx
@@ -113,9 +113,9 @@ function canPerformAction(action: InstanceAction, instance: Instance): boolean {
     case 'stop':
       return status === 'running' || status === 'frozen';
     case 'restart':
-      return status === 'running';
+      return status === 'running' || status === 'started';
     case 'freeze':
-      return status === 'running';
+      return status === 'running' || status === 'started';
     default:
       return false;
   }


### PR DESCRIPTION
# Mass Action Filtering

## Summary
This PR improves the user experience for mass actions on the instances page by filtering available actions based on the state of the selected instances. It ensures that users only see relevant actions (e.g., "Start" for stopped instances) and that actions are only applied to valid targets.

## Key Features
- **State-Based Action Filtering**: Mass action buttons (Start, Stop, Restart, Freeze) are now dynamically shown/hidden based on the status of the selected instances.
    - **Start**: Visible if any selected instance is `STOPPED`.
    - **Stop**: Visible if any selected instance is `RUNNING` or `FROZEN`.
    - **Restart**: Visible if any selected instance is `RUNNING`.
    - **Freeze**: Visible if any selected instance is `RUNNING`.
- **Targeted Execution**: When a mass action is triggered, it is intelligently applied only to the instances for which the action is valid, ignoring others in the selection.

## Verification
- [x] Select a `STOPPED` instance and verify only the "Start" button is visible.
- [x] Select a `RUNNING` instance and verify "Stop", "Restart", and "Freeze" buttons are visible.
- [x] Select both a `STOPPED` and `RUNNING` instance:
    - Verify all action buttons are visible.
    - Click "Start" and verify only the stopped instance receives the command.
    - Click "Stop" and verify only the running instance receives the command.
    
    closes #70 