### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/_context/user.tsx
+++ b/app/(main)/_context/user.tsx
@@ -3,9 +3,6 @@
 
 import { useUser } from "@/app/_hooks/user";
 import { createContext, use } from 'react';
-import AuthenticationContext, {
-  AuthenticationContextData,
-} from '../../_context/authentication';
 import { useClientCertificate } from '@/app/_hooks/certificate';
 import IsClientContext from '@/app/_context/isClient';
 


### PR DESCRIPTION
To fix the problem, remove the unused imports so that every imported symbol is actually referenced in the file. This resolves the CodeQL warning, reduces clutter, and avoids misleading future maintainers.

Concretely, in `app/(main)/_context/user.tsx`, delete the import of `AuthenticationContext` and `AuthenticationContextData` from `'../../_context/authentication'` (lines 6–8 in the snippet). No other changes are required because those names are not used anywhere in the file. All functionality of `UserContext` and `UserProvider` remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._