### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/_components/devices.tsx
+++ b/app/(main)/_components/devices.tsx
@@ -54,7 +54,6 @@ import type { Device } from '@/app/(main)/instances/_lib/instances.d';
 import type { ConfigOption } from '@/app/_lib/server.d';
 import { useResources } from '@/app/(main)/_hooks/resources';
 import { VerticalTabsLayout } from '@/app/_components/layout/vertical-tabs-layout';
-import { useMobile } from 'ui-web/hooks/use-mobile';
 
 // Utility function to validate port specifications (Issue 3)
 function validatePort(portSpec: string): boolean {


### PR DESCRIPTION
To fix an unused import, the general approach is to remove that specific import (or imported symbol) from the file so that the module only depends on what it actually uses. This avoids unnecessary dependencies and clarifies the code.

In this case, the best fix is simply to delete the line importing `useMobile` from `ui-web/hooks/use-mobile` in `app/(main)/_components/devices.tsx`. No other code change is required, as `useMobile` is not referenced elsewhere in the shown snippet. This change preserves all existing functionality while removing dead code.

Concretely:
- In `app/(main)/_components/devices.tsx`, remove line 57:
  - `import { useMobile } from 'ui-web/hooks/use-mobile';`
- No new methods, definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._