### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/_components/devices.tsx
+++ b/app/(main)/_components/devices.tsx
@@ -611,10 +611,6 @@ function AddDeviceForm({
   );
   // Counter used to force a rerender/reset of certain controlled inputs (e.g. pool combobox)
   const [resetCounter, setResetCounter] = React.useState(0);
-  // Track field-level validation errors (centralized)
-  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>(
-    {},
-  );
   // Check if a root disk already exists
   const hasRootDiskAlready = React.useMemo(() => {
     const allDevices = { ...inheritedDevices, ...existingDevices };


### PR DESCRIPTION
In general, the best fix for an unused state variable in React is to remove both the state declaration and any associated logic that references it, provided that doing so does not change behavior (i.e., the variable was truly unused). If the intent was to add validation, then the correct fix would be to implement that logic; however, without evidence and to avoid changing functionality, we should instead eliminate the dead code.

Concretely, in `app/(main)/_components/devices.tsx`, inside the `AddDeviceForm` function, remove the `fieldErrors` state definition at lines 615–617:

```ts
  // Track field-level validation errors (centralized)
  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>(
    {},
  );
```

No additional imports or methods are required, since `React` is already imported and we are only deleting code. This change will not affect any observed functionality because that state was never used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._