### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/_components/devices.tsx
+++ b/app/(main)/_components/devices.tsx
@@ -1480,9 +1480,6 @@ function AddDeviceForm({
     const isBool = config.type === 'bool';
     const hasCondition =
       config.condition && typeof config.condition === 'string';
-    // errorId removed (unused variable)
-    
-    const errorId = `${fieldId}-error`;
 
     // Check if field should be shown using centralized logic
     if (!shouldShowField(fieldKey, config)) {


### PR DESCRIPTION
To fix this, the unused variable declaration should be removed from the `renderField` function. This eliminates the CodeQL warning without changing any existing behavior, because `errorId` is not referenced anywhere else in the snippet.

Concretely:
- In `app/(main)/_components/devices.tsx`, within the `renderField` function, delete the line `const errorId = \`${fieldId}-error\`;`.
- No additional imports, methods, or definitions are required.
- Ensure no other part of the snippet still expects `errorId`; since there are no references, this is safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._