### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,7 +1,6 @@
 import AppSidebar from '@/app/(main)/sidebar';
 import { ProjectsProvider } from '@/app/(main)/_context/projects';
 import { UserProvider } from '@/app/(main)/_context/user';
-import { SiteHeader } from '@/app/(main)/_components/header';
 import { SidebarInset, SidebarProvider } from 'ui-web/components/sidebar';
 
 export default function DashboardLayout({


### PR DESCRIPTION
Generally, to fix unused import issues, remove the unused import statement (or the specific unused specifier) if the symbol truly is not needed, or else update the code to actually use the imported symbol if it was meant to be used.

Here, the best fix without changing functionality is to delete the `SiteHeader` import line from `app/(main)/layout.tsx`, because `SiteHeader` is never referenced in `DashboardLayout`. No other code needs to change, and no new imports or helpers are required. Specifically, remove line 4 (`import { SiteHeader } from '@/app/(main)/_components/header';`) and leave the remaining imports and component implementation unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._