### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/app/(main)/_context/user.tsx
+++ b/app/(main)/_context/user.tsx
@@ -3,7 +3,6 @@
 
 import { useUser } from "@/app/_hooks/user";
 import { createContext, use } from 'react';
-import { useClientCertificate } from '@/app/_hooks/certificate';
 import IsClientContext from '@/app/_context/isClient';
 
 export interface UserContextData {


### PR DESCRIPTION
To fix the problem, remove the unused named import `useClientCertificate` from the file so that only actually used imports remain. This will clean up the code, avoid confusion, and potentially reduce bundle size, without changing the runtime behavior of the component.

Concretely, in `app/(main)/_context/user.tsx`, delete the line that imports `useClientCertificate` from `@/app/_hooks/certificate`. No other code changes are required, and no additional methods, imports, or definitions are needed, since nothing in the file references `useClientCertificate`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._