### PR TITLE
Add event-driven SWR revalidation

### DIFF
--- a/app/(main)/_components/files.tsx
+++ b/app/(main)/_components/files.tsx
@@ -59,11 +59,7 @@ interface FileBrowserProps {
   onDelete: (path: string) => Promise<void>;
   onDownload: (path: string) => void;
   onFetchContent: (path: string) => Promise<{ content: string; mode?: string }>;
-  onSaveContent: (
-    path: string,
-    content: string,
-    mode?: string,
-  ) => Promise<void>;
+  onSaveContent: (path: string, content: string, mode?: string) => Promise<void>;
 }
 
 export interface FileItem {
@@ -195,8 +191,7 @@ export function FileBrowser({
         const name = row.original.name;
         const type = row.original.type;
         // Fallback to extension check if type is missing
-        const isDirectory =
-          type === 'directory' || (!type && !name.includes('.'));
+        const isDirectory = type === 'directory' || (!type && !name.includes('.'));
 
         return (
           <div className="flex items-center gap-2">
@@ -206,12 +201,10 @@ export function FileBrowser({
               <FileIcon className="h-4 w-4 text-gray-500" />
             )}
             <span
-              className="font-medium cursor-pointer hover:underline"
+              className="cursor-pointer font-medium select-none hover:underline"
               onClick={() => {
                 if (isDirectory) {
-                  onNavigate(
-                    `${currentPath === '/' ? '' : currentPath}/${name}`,
-                  );
+                  onNavigate(`${currentPath === '/' ? '' : currentPath}/${name}`);
                 } else {
                   handleEdit(name);
                 }
@@ -247,8 +240,7 @@ export function FileBrowser({
       cell: ({ row }) => {
         const name = row.original.name;
         const type = row.original.type;
-        const isDirectory =
-          type === 'directory' || (!type && !name.includes('.'));
+        const isDirectory = type === 'directory' || (!type && !name.includes('.'));
         const fullPath = `${currentPath === '/' ? '' : currentPath}/${name}`;
 
         return (
@@ -278,9 +270,7 @@ export function FileBrowser({
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  onClick={() =>
-                    onDelete(fullPath).catch((e) => setActionError(e.message))
-                  }
+                  onClick={() => onDelete(fullPath).catch((e) => setActionError(e.message))}
                   className="text-red-600"
                 >
                   <TrashIcon className="mr-2 h-4 w-4" />
@@ -296,7 +286,7 @@ export function FileBrowser({
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-between items-center">
+      <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Button
             variant="outline"
@@ -311,7 +301,7 @@ export function FileBrowser({
               <BreadcrumbItem>
                 <BreadcrumbLink
                   onClick={() => onNavigate('/')}
-                  className="cursor-pointer"
+                  className="cursor-pointer select-none"
                 >
                   <HomeIcon className="h-4 w-4" />
                 </BreadcrumbLink>
@@ -322,7 +312,7 @@ export function FileBrowser({
                   <BreadcrumbItem>
                     <BreadcrumbLink
                       onClick={() => !editingFile && onNavigate(crumb.path)}
-                      className={!editingFile ? 'cursor-pointer' : ''}
+                      className={!editingFile ? 'cursor-pointer select-none' : 'select-none'}
                     >
                       {crumb.name}
                     </BreadcrumbLink>
@@ -335,11 +325,7 @@ export function FileBrowser({
 
         {editingFile ? (
           <div className="flex gap-2">
-            <Button
-              variant="outline"
-              onClick={handleCancel}
-              disabled={isSaving}
-            >
+            <Button variant="outline" onClick={handleCancel} disabled={isSaving}>
               <XIcon className="mr-2 h-4 w-4" />
               Cancel
             </Button>
@@ -358,17 +344,13 @@ export function FileBrowser({
               currentPath={currentPath}
               open={isCreateDirOpen}
               onOpenChange={setIsCreateDirOpen}
-              onCreate={(name) =>
-                onCreateDirectory(name).catch((e) => setActionError(e.message))
-              }
+              onCreate={(name) => onCreateDirectory(name).catch((e) => setActionError(e.message))}
             />
             <UploadFileDialog
               currentPath={currentPath}
               open={isUploadOpen}
               onOpenChange={setIsUploadOpen}
-              onUpload={(file) =>
-                onUpload(file).catch((e) => setActionError(e.message))
-              }
+              onUpload={(file) => onUpload(file).catch((e) => setActionError(e.message))}
             />
           </div>
         )}
@@ -414,11 +396,7 @@ export function FileBrowser({
                 <AlertDescription>Failed to load files.</AlertDescription>
               </Alert>
             ) : (
-              <DataTable
-                data={fileData}
-                cols={columns as any}
-                disablePagination
-              />
+              <DataTable data={fileData} cols={columns as any} disablePagination />
             )}
           </>
         )}
@@ -464,9 +442,7 @@ function CreateDirectoryDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create Directory</DialogTitle>
-          <DialogDescription>
-            Create a new directory in {currentPath}.
-          </DialogDescription>
+          <DialogDescription>Create a new directory in {currentPath}.</DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">

--- a/app/(main)/_components/files.tsx
+++ b/app/(main)/_components/files.tsx
@@ -201,7 +201,7 @@ export function FileBrowser({
               <FileIcon className="h-4 w-4 text-gray-500" />
             )}
             <span
-              className="cursor-pointer font-medium select-none hover:underline"
+              className="cursor-pointer font-medium hover:underline"
               onClick={() => {
                 if (isDirectory) {
                   onNavigate(`${currentPath === '/' ? '' : currentPath}/${name}`);

--- a/app/(main)/_components/files.tsx
+++ b/app/(main)/_components/files.tsx
@@ -312,7 +312,7 @@ export function FileBrowser({
                   <BreadcrumbItem>
                     <BreadcrumbLink
                       onClick={() => !editingFile && onNavigate(crumb.path)}
-                      className={!editingFile ? 'cursor-pointer select-none' : 'select-none'}
+                      className={!editingFile ? 'cursor-pointer' : ''}
                     >
                       {crumb.name}
                     </BreadcrumbLink>

--- a/app/(main)/instance/_hooks/backups.ts
+++ b/app/(main)/instance/_hooks/backups.ts
@@ -1,4 +1,4 @@
-import useSWR, { mutate } from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 import { jsonFetcher } from '../../../_lib/fetcher';
 import { Backup } from '../../_components/backups';
 import { StandardResponse } from '../../../_lib/response';
@@ -10,6 +10,7 @@ import {
 } from '../_lib/backups';
 
 export function useBackups(instanceName: string) {
+  const { mutate } = useSWRConfig();
   const { data, error, isLoading } = useSWR<StandardResponse<Backup[]>>(
     `/1.0/instances/${instanceName}/backups?recursion=1`,
     (url: string) => jsonFetcher<Backup[]>(url),

--- a/app/(main)/instance/_hooks/files.ts
+++ b/app/(main)/instance/_hooks/files.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import useSWR, { mutate } from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 import {
   uploadFile as apiUploadFile,
   createDirectory as apiCreateDirectory,
@@ -10,38 +10,70 @@ import {
   getFileMetadata as apiFetchFileMetadata,
 } from '../_lib/files';
 
+type DirectoryResponse = {
+  type: 'sync';
+  metadata: string[];
+};
+
+type FileWithMetadata = {
+  name: string;
+  type?: string;
+  size?: number;
+  mode?: string;
+  uid?: string;
+  gid?: string;
+};
+
+function isDirectoryResponse(value: unknown): value is DirectoryResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    value.type === 'sync' &&
+    'metadata' in value &&
+    Array.isArray(value.metadata)
+  );
+}
+
 const directoryFetcher = async (url: string) => {
   const res = await fetch(url);
   if (!res.ok) {
-    const error = new Error('An error occurred while fetching the data.');
-    (error as any).status = res.status;
+    const error: Error & { status?: number } = new Error(
+      'An error occurred while fetching the data.',
+    );
+    error.status = res.status;
     throw error;
   }
 
   const text = await res.text();
   try {
-    const json = JSON.parse(text);
-    if (json.type === 'sync' && Array.isArray(json.metadata)) {
+    const json: unknown = JSON.parse(text);
+    if (isDirectoryResponse(json)) {
       return json;
     }
-  } catch (e) {
+  } catch {
     // Not JSON
   }
 
   throw new Error('NOT_A_DIRECTORY');
 };
 
+function buildFilesCacheKey(instanceName: string, path: string) {
+  return `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(path)}`;
+}
+
 export function useFiles(instanceName: string, path: string) {
+  const { mutate } = useSWRConfig();
   // Ensure path starts with /
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
 
   // Fetch file listing
   const { data, error, isLoading } = useSWR(
-    `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(normalizedPath)}`,
+    buildFilesCacheKey(instanceName, normalizedPath),
     directoryFetcher,
   );
 
-  const [filesWithMetadata, setFilesWithMetadata] = useState<any[]>([]);
+  const [filesWithMetadata, setFilesWithMetadata] = useState<FileWithMetadata[]>([]);
   const [isMetadataLoading, setIsMetadataLoading] = useState(false);
 
   useEffect(() => {
@@ -60,11 +92,11 @@ export function useFiles(instanceName: string, path: string) {
             const meta = await apiFetchFileMetadata(instanceName, filePath);
             return {
               name: fileName,
-              type: meta.type,
+              type: meta.type ?? undefined,
               size: meta.size ? parseInt(meta.size, 10) : undefined,
-              mode: meta.mode,
-              uid: meta.uid,
-              gid: meta.gid,
+              mode: meta.mode ?? undefined,
+              uid: meta.uid ?? undefined,
+              gid: meta.gid ?? undefined,
             };
           } catch (e) {
             console.error(`Failed to fetch metadata for ${fileName}`, e);
@@ -86,25 +118,18 @@ export function useFiles(instanceName: string, path: string) {
 
   const uploadFile = async (currentPath: string, file: File) => {
     await apiUploadFile(instanceName, currentPath, file);
-    await mutate(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(currentPath)}`,
-    );
+    await mutate(buildFilesCacheKey(instanceName, currentPath));
   };
 
   const createDirectory = async (currentPath: string, dirName: string) => {
     await apiCreateDirectory(instanceName, currentPath, dirName);
-    await mutate(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(currentPath)}`,
-    );
+    await mutate(buildFilesCacheKey(instanceName, currentPath));
   };
 
   const deleteFile = async (filePath: string) => {
     await apiDeleteFile(instanceName, filePath);
-    // Mutate the parent directory
     const parentPath = filePath.substring(0, filePath.lastIndexOf('/')) || '/';
-    await mutate(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(parentPath)}`,
-    );
+    await mutate(buildFilesCacheKey(instanceName, parentPath));
   };
 
   const downloadFile = (filePath: string) => {
@@ -115,17 +140,15 @@ export function useFiles(instanceName: string, path: string) {
     return apiFetchFileContent(instanceName, filePath);
   };
 
-  const saveFileContent = async (
-    filePath: string,
-    content: string,
-    mode?: string,
-  ) => {
+  const saveFileContent = async (filePath: string, content: string, mode?: string) => {
     await apiSaveFileContent(instanceName, filePath, content, mode);
+    const parentPath = filePath.substring(0, filePath.lastIndexOf('/')) || '/';
+    await mutate(buildFilesCacheKey(instanceName, parentPath));
   };
 
   return {
     files: filesWithMetadata,
-    isLoading: isLoading || isMetadataLoading,
+    isLoading: isLoading || (isMetadataLoading && filesWithMetadata.length === 0),
     isError: error,
     uploadFile,
     createDirectory,

--- a/app/(main)/instance/_hooks/snapshots.ts
+++ b/app/(main)/instance/_hooks/snapshots.ts
@@ -1,4 +1,4 @@
-import { mutate } from 'swr';
+import { useSWRConfig } from 'swr';
 import {
   createSnapshot as apiCreateSnapshot,
   deleteSnapshot as apiDeleteSnapshot,
@@ -7,6 +7,8 @@ import {
 } from '../_lib/snapshots';
 
 export function useSnapshots(instanceName: string) {
+  const { mutate } = useSWRConfig();
+
   const createSnapshot = async (name?: string, stateful?: boolean) => {
     await apiCreateSnapshot(instanceName, name, stateful);
     await mutate(`/1.0/instances/${instanceName}?recursion=1`);

--- a/app/(main)/instance/files/page.tsx
+++ b/app/(main)/instance/files/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React from 'react';
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { useInstanceContext } from '../_context/instance';
 import { useFiles } from '../_hooks/files';
 import { Spinner } from 'ui-web/components/spinner';
 import { FileBrowser } from '../../_components/files';
+import type { Instance } from '../../instances/_lib/instances.d';
 
 export default function FilesPage() {
   const { instance, isLoading } = useInstanceContext();
@@ -21,45 +22,22 @@ export default function FilesPage() {
   return <Files instance={instance} />;
 }
 
-function Files({ instance }: { instance: any }) {
+function Files({ instance }: { instance: Instance }) {
   const router = useRouter();
   const pathname = usePathname();
-  const [currentPath, setCurrentPath] = React.useState('/');
-
-  // Read path from URL on mount using manual JS
-  React.useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search);
-      const pathParam = params.get('path') || '/';
-      setCurrentPath(pathParam);
-    }
-  }, []);
-
-  // Listen for back/forward navigation
-  React.useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const handlePopState = () => {
-      const params = new URLSearchParams(window.location.search);
-      const pathParam = params.get('path') || '/';
-      setCurrentPath(pathParam);
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
+  const searchParams = useSearchParams();
+  const currentPath = searchParams.get('path') || '/';
 
   const handleNavigate = (path: string) => {
-    setCurrentPath(path);
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search);
-      if (path === '/') {
-        params.delete('path');
-      } else {
-        params.set('path', path);
-      }
-      router.push(`${pathname}?${params.toString()}`);
+    const params = new URLSearchParams(searchParams.toString());
+    if (path === '/') {
+      params.delete('path');
+    } else {
+      params.set('path', path);
     }
+
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname);
   };
 
   const {

--- a/app/(main)/instances/_hooks/instances.ts
+++ b/app/(main)/instances/_hooks/instances.ts
@@ -27,7 +27,7 @@ function shouldSeedUnscopedInstanceDetail(project: string | null | undefined, in
 }
 
 export function useInstances(project?: string | null) {
-  const { mutate: mutateCache } = useSWRConfig();
+  const { cache, mutate: mutateCache } = useSWRConfig();
   const url = buildApiPath('/1.0/instances', {
     project: project ?? null,
     params: { recursion: 2 },
@@ -42,13 +42,12 @@ export function useInstances(project?: string | null) {
         continue;
       }
 
-      void mutateCache(
-        `/1.0/instances/${instance.name}?recursion=1`,
-        buildInstanceDetailCacheValue(instance),
-        { revalidate: false },
-      );
+      const detailKey = `/1.0/instances/${instance.name}?recursion=1`;
+      if (cache.get(detailKey) === undefined) {
+        void mutateCache(detailKey, buildInstanceDetailCacheValue(instance), { revalidate: false });
+      }
     }
-  }, [mutateCache, project, result.data]);
+  }, [cache, mutateCache, project, result.data]);
 
   return result;
 }

--- a/app/(main)/instances/_hooks/instances.ts
+++ b/app/(main)/instances/_hooks/instances.ts
@@ -1,16 +1,54 @@
 import type { InstancesResponse } from '../_lib/instances.d';
-import useSWR from 'swr';
+import { useEffect } from 'react';
+import useSWR, { useSWRConfig } from 'swr';
 import { buildApiPath } from '@/app/_lib/url';
+import type { StandardResponse } from '@/app/_lib/response.d';
+import type { Instance } from '../_lib/instances.d';
 
 const fetcher = (...args: Parameters<typeof fetch>) =>
   fetch(...args)
     .then((res) => res.json())
     .then((data: InstancesResponse) => data.metadata);
 
+function buildInstanceDetailCacheValue(instance: Instance): StandardResponse<Instance> {
+  return {
+    type: 'sync',
+    status: 'Success',
+    status_code: 200,
+    metadata: instance,
+  };
+}
+
+function shouldSeedUnscopedInstanceDetail(project: string | null | undefined, instance: Instance) {
+  const isDefaultProject = !project || project === 'default';
+  const isDefaultInstance = !instance.project || instance.project === 'default';
+
+  return isDefaultProject && isDefaultInstance;
+}
+
 export function useInstances(project?: string | null) {
+  const { mutate: mutateCache } = useSWRConfig();
   const url = buildApiPath('/1.0/instances', {
     project: project ?? null,
     params: { recursion: 2 },
   });
-  return useSWR(url, fetcher);
+  const result = useSWR(url, fetcher);
+
+  useEffect(() => {
+    if (!result.data) return;
+
+    for (const instance of result.data) {
+      if (!shouldSeedUnscopedInstanceDetail(project, instance)) {
+        continue;
+      }
+
+      void mutateCache(
+        `/1.0/instances/${instance.name}?recursion=1`,
+        buildInstanceDetailCacheValue(instance),
+        { revalidate: false },
+      );
+    }
+  }, [mutateCache, project, result.data]);
+
+  return result;
 }

--- a/app/_context/events.tsx
+++ b/app/_context/events.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useEffect, useState, useRef } from 'react';
 import { toast } from 'sonner';
+import { useSWRConfig, type Cache } from 'swr';
 
 type EventType = 'operation' | 'logging' | 'lifecycle';
 
@@ -9,6 +10,7 @@ interface IncusEvent {
   type: EventType;
   timestamp: string;
   metadata: unknown;
+  project?: string;
 }
 
 interface OperationMetadata {
@@ -30,6 +32,12 @@ interface OperationMetadata {
   location: string;
 }
 
+interface LifecycleMetadata {
+  action: string;
+  source?: string;
+  context?: Record<string, unknown>;
+}
+
 type EventEmitterContextValue = {
   isConnected: boolean;
 };
@@ -45,11 +53,138 @@ const INITIAL_RECONNECT_DELAY_MS = 3000;
 // Maximum reconnect delay in milliseconds
 const MAX_RECONNECT_DELAY_MS = 30000;
 
-export function EventEmitterProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+const TERMINAL_OPERATION_STATUSES = new Set(['Success', 'Failure', 'Cancelled']);
+const INSTANCE_FILE_LIFECYCLE_ACTIONS = new Set(['instance-file-deleted', 'instance-file-pushed']);
+
+function normalizePath(path: string) {
+  if (path.length > 1 && path.endsWith('/')) {
+    return path.slice(0, -1);
+  }
+  return path;
+}
+
+function getPathname(value: string) {
+  try {
+    return normalizePath(new URL(value, window.location.origin).pathname);
+  } catch {
+    return normalizePath(value.split('?')[0] || '');
+  }
+}
+
+function getParentPath(path: string) {
+  const index = path.lastIndexOf('/');
+  if (index <= 0) return null;
+  return path.slice(0, index);
+}
+
+function getNestedInstanceDetailPath(path: string) {
+  if (!isInstanceResourcePath(path)) return null;
+
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length <= 3) return null;
+
+  return `/${segments.slice(0, 3).join('/')}`;
+}
+
+function getInstanceFilesPath(path: string, context?: Record<string, unknown>) {
+  const instancePath = getNestedInstanceDetailPath(path) ?? path;
+  if (!isInstanceResourcePath(instancePath)) return null;
+
+  const filePath =
+    typeof context?.path === 'string'
+      ? context.path
+      : typeof context?.file === 'string'
+        ? context.file
+        : typeof context?.['file-destination'] === 'string'
+          ? context['file-destination']
+          : typeof context?.['file-source'] === 'string'
+            ? context['file-source']
+            : null;
+
+  if (!filePath) return null;
+
+  const parentPath = filePath.substring(0, filePath.lastIndexOf('/')) || '/';
+  return `${instancePath}/files?path=${encodeURIComponent(parentPath)}`;
+}
+
+function isProjectMatch(params: URLSearchParams, project?: string) {
+  if (params.get('all-projects') === 'true') return true;
+
+  const keyProject = params.get('project');
+  if (keyProject) {
+    return Boolean(project) && keyProject === project;
+  }
+
+  return !project || project === 'default';
+}
+
+function parseCacheKey(key: unknown) {
+  if (typeof key !== 'string') return null;
+
+  try {
+    const url = new URL(key, window.location.origin);
+    return {
+      pathname: normalizePath(url.pathname),
+      params: url.searchParams,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isSameCacheKeyPath(key: unknown, target: string) {
+  const parsedKey = parseCacheKey(key);
+  const parsedTarget = parseCacheKey(target);
+
+  return (
+    parsedKey?.pathname === parsedTarget?.pathname &&
+    parsedKey?.params.toString() === parsedTarget?.params.toString()
+  );
+}
+
+function getResourcePaths(resources: OperationMetadata['resources']) {
+  return Array.from(
+    new Set(
+      Object.values(resources)
+        .flat()
+        .map((resource) => getPathname(resource))
+        .filter(Boolean),
+    ),
+  );
+}
+
+function isInstanceResourcePath(path: string) {
+  return path.startsWith('/1.0/instances/');
+}
+
+function hasMatchingCollectionKey(cache: Cache, collectionPath: string, project?: string) {
+  for (const key of cache.keys()) {
+    const parsed = parseCacheKey(key);
+    if (parsed?.pathname === collectionPath && isProjectMatch(parsed.params, project)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getLifecycleToastMessage(action: string) {
+  const messages: Record<string, string> = {
+    'instance-file-deleted': 'File deleted',
+    'instance-file-pushed': 'File saved',
+    'instance-paused': 'Instance paused',
+    'instance-restarted': 'Instance restarted',
+    'instance-resumed': 'Instance resumed',
+    'instance-shutdown': 'Instance shut down',
+    'instance-started': 'Instance started',
+    'instance-stopped': 'Instance stopped',
+  };
+
+  return messages[action];
+}
+
+export function EventEmitterProvider({ children }: { children: React.ReactNode }) {
+  const { cache, mutate } = useSWRConfig();
   const [isConnected, setIsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
   // Track operations we are already showing toasts for to avoid duplicates/spam
@@ -60,6 +195,7 @@ export function EventEmitterProvider({
       return;
     }
 
+    const activeOperationIds = activeOperations.current;
     let reconnectAttempts = 0;
     let reconnectTimeout: number | undefined;
 
@@ -76,7 +212,7 @@ export function EventEmitterProvider({
         setIsConnected(true);
         reconnectAttempts = 0;
         // Clear activeOperations on reconnect to avoid memory leaks
-        activeOperations.current.clear();
+        activeOperationIds.clear();
       };
 
       ws.onclose = () => {
@@ -102,7 +238,9 @@ export function EventEmitterProvider({
           const data = JSON.parse(event.data) as IncusEvent;
 
           if (data.type === 'operation') {
-            handleOperationEvent(data.metadata as OperationMetadata);
+            handleOperationEvent(data.metadata as OperationMetadata, data.project);
+          } else if (data.type === 'lifecycle') {
+            handleLifecycleEvent(data.metadata as LifecycleMetadata, data.project);
           }
         } catch (e) {
           console.error('Failed to parse event data:', e);
@@ -110,15 +248,113 @@ export function EventEmitterProvider({
       };
     };
 
-    const handleOperationEvent = (op: OperationMetadata) => {
+    const revalidateResourceCaches = (
+      resources: OperationMetadata['resources'],
+      project?: string,
+    ) => {
+      const resourcePaths = getResourcePaths(resources);
+      if (!resourcePaths.length) return;
+
+      const exactPaths = new Set<string>();
+      const collectionPaths = new Set<string>();
+
+      for (const resourcePath of resourcePaths) {
+        const collectionPath = getParentPath(resourcePath);
+        if (!collectionPath) continue;
+
+        collectionPaths.add(collectionPath);
+
+        const nestedInstanceDetailPath = getNestedInstanceDetailPath(resourcePath);
+        if (nestedInstanceDetailPath) {
+          exactPaths.add(nestedInstanceDetailPath);
+        }
+
+        if (isInstanceResourcePath(resourcePath)) {
+          exactPaths.add(resourcePath);
+        }
+
+        if (
+          !isInstanceResourcePath(resourcePath) ||
+          !hasMatchingCollectionKey(cache, collectionPath, project)
+        ) {
+          exactPaths.add(resourcePath);
+        }
+      }
+
+      for (const key of cache.keys()) {
+        const parsed = parseCacheKey(key);
+        if (!parsed || !isProjectMatch(parsed.params, project)) {
+          continue;
+        }
+
+        if (collectionPaths.has(parsed.pathname) || exactPaths.has(parsed.pathname)) {
+          void mutate(key);
+        }
+      }
+    };
+
+    const revalidateLifecycleCaches = (lifecycle: LifecycleMetadata, project?: string) => {
+      if (!lifecycle.source) return;
+
+      const sourcePath = getPathname(lifecycle.source);
+      const filesPath = getInstanceFilesPath(sourcePath, lifecycle.context);
+      if (INSTANCE_FILE_LIFECYCLE_ACTIONS.has(lifecycle.action)) {
+        if (!filesPath) return;
+
+        for (const key of cache.keys()) {
+          const parsed = parseCacheKey(key);
+          if (!parsed || !isProjectMatch(parsed.params, project)) {
+            continue;
+          }
+
+          if (isSameCacheKeyPath(key, filesPath)) {
+            void mutate(key);
+          }
+        }
+
+        return;
+      }
+
+      const collectionPath = getParentPath(sourcePath);
+      const nestedInstanceDetailPath = getNestedInstanceDetailPath(sourcePath);
+      const exactPaths = new Set<string>([sourcePath]);
+      const collectionPaths = new Set<string>();
+
+      if (collectionPath) {
+        collectionPaths.add(collectionPath);
+      }
+
+      if (nestedInstanceDetailPath) {
+        exactPaths.add(nestedInstanceDetailPath);
+      }
+
+      for (const key of cache.keys()) {
+        const parsed = parseCacheKey(key);
+        if (!parsed || !isProjectMatch(parsed.params, project)) {
+          continue;
+        }
+
+        const shouldRevalidate =
+          (parsed.pathname === '/1.0/instances' && isInstanceResourcePath(sourcePath)) ||
+          collectionPaths.has(parsed.pathname) ||
+          exactPaths.has(parsed.pathname);
+
+        if (shouldRevalidate) {
+          void mutate(key);
+        }
+      }
+    };
+
+    const handleOperationEvent = (op: OperationMetadata, project?: string) => {
       // status: Pending, Running, Success, Failure, Cancelled
 
       const toastId = op.id;
       const description = op.description || 'Operation';
+      const isTerminalStatus = TERMINAL_OPERATION_STATUSES.has(op.status);
 
       // If it's a new operation we haven't seen, or an update to one we are tracking
       if (op.status === 'Pending' || op.status === 'Running') {
-        activeOperations.current.add(toastId);
+        activeOperationIds.add(toastId);
 
         let progressDetails = '';
         if (op.metadata) {
@@ -141,20 +377,33 @@ export function EventEmitterProvider({
           id: toastId,
           description: 'Completed successfully',
         });
-        activeOperations.current.delete(toastId);
+        activeOperationIds.delete(toastId);
       } else if (op.status === 'Failure') {
         toast.error(description, {
           id: toastId,
           description: op.err || 'Operation failed',
         });
-        activeOperations.current.delete(toastId);
+        activeOperationIds.delete(toastId);
       } else if (op.status === 'Cancelled') {
         toast.info(description, {
           id: toastId,
           description: 'Cancelled',
         });
-        activeOperations.current.delete(toastId);
+        activeOperationIds.delete(toastId);
       }
+
+      if (isTerminalStatus) {
+        revalidateResourceCaches(op.resources, project);
+      }
+    };
+
+    const handleLifecycleEvent = (lifecycle: LifecycleMetadata, project?: string) => {
+      const message = getLifecycleToastMessage(lifecycle.action);
+      if (message) {
+        toast.success(message);
+      }
+
+      revalidateLifecycleCaches(lifecycle, project);
     };
 
     connect();
@@ -168,13 +417,11 @@ export function EventEmitterProvider({
         wsRef.current.close();
         wsRef.current = null;
       }
-      activeOperations.current.clear();
+      activeOperationIds.clear();
     };
-  }, []);
+  }, [cache, mutate]);
 
   return (
-    <EventEmitterContext.Provider value={{ isConnected }}>
-      {children}
-    </EventEmitterContext.Provider>
+    <EventEmitterContext.Provider value={{ isConnected }}>{children}</EventEmitterContext.Provider>
   );
 }

--- a/app/_context/events.tsx
+++ b/app/_context/events.tsx
@@ -132,16 +132,6 @@ function parseCacheKey(key: unknown) {
   }
 }
 
-function isSameCacheKeyPath(key: unknown, target: string) {
-  const parsedKey = parseCacheKey(key);
-  const parsedTarget = parseCacheKey(target);
-
-  return (
-    parsedKey?.pathname === parsedTarget?.pathname &&
-    parsedKey?.params.toString() === parsedTarget?.params.toString()
-  );
-}
-
 function getResourcePaths(resources: OperationMetadata['resources']) {
   return Array.from(
     new Set(
@@ -301,13 +291,19 @@ export function EventEmitterProvider({ children }: { children: React.ReactNode }
       if (INSTANCE_FILE_LIFECYCLE_ACTIONS.has(lifecycle.action)) {
         if (!filesPath) return;
 
+        const parsedFilesPath = parseCacheKey(filesPath);
+        if (!parsedFilesPath) return;
+
         for (const key of cache.keys()) {
           const parsed = parseCacheKey(key);
           if (!parsed || !isProjectMatch(parsed.params, project)) {
             continue;
           }
 
-          if (isSameCacheKeyPath(key, filesPath)) {
+          if (
+            parsed.pathname === parsedFilesPath.pathname &&
+            parsed.params.toString() === parsedFilesPath.params.toString()
+          ) {
             void mutate(key);
           }
         }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,12 @@ const eslintConfig = defineConfig([
     'out/**',
     'build/**',
     'next-env.d.ts',
+    '.agents/**',
+    '.claude/**',
+    '.codex/**',
+    '.cursor/**',
+    '.github/**',
+    '.kiro/**',
   ]),
 ]);
 


### PR DESCRIPTION
## Summary
- Add targeted SWR revalidation from Incus operation and lifecycle events, including instance state, snapshots, backups, and file changes.
- Use the active SWR config cache/mutate path so updates work with the app cache provider.
- Preserve direct file mutation fallbacks for the initiating tab when WebSocket events are missed.
- Avoid cross-project and stale overwrites when seeding instance detail cache entries.
- Fix file manager URL path handling and prevent selecting file/breadcrumb link text.
- Ignore local tool/output directories in ESLint config.

## Testing
- `bun run build`
- Focused ESLint/Prettier checks on touched files
- `bun run lint` still reports existing app/source lint issues, but no longer checks `.agents`, `.claude`, `.codex`, `.cursor`, `.github`, `.kiro`, `.next`, or `out`