### PR TITLE
Add instance actions menu & image selector updates

### DIFF
--- a/app/(main)/_components/image-selector.tsx
+++ b/app/(main)/_components/image-selector.tsx
@@ -478,7 +478,7 @@ export default function ImageSelector({
             }`}
           >
             <DataTable
-              className="h-full [&>div]:h-full [&>div]:overflow-hidden [&>div>div]:h-full"
+              className="h-full [&>div]:h-full [&>div]:overflow-auto [&>div>div]:h-full"
               stringFilter={stringFilter}
               cols={columns}
               data={images}

--- a/app/(main)/_components/image-selector.tsx
+++ b/app/(main)/_components/image-selector.tsx
@@ -78,17 +78,37 @@ export default function ImageSelector({
   selectedImage,
   onSelect,
   instanceType,
+  project,
+  projectLabel,
+  emptyDescription = 'Select an image to define the instance base.',
+  defaultSelection,
 }: {
   selectedImage: SelectableImage | null;
   onSelect: (image: SelectableImage) => void;
   instanceType?: 'virtual-machine' | 'container';
+  project?: string | null;
+  projectLabel?: string;
+  emptyDescription?: string;
+  defaultSelection?: {
+    fingerprint?: string | null;
+    alias?: string | null;
+    description?: string | null;
+  };
 }) {
   const { currentProject } = use(ProjectsContext);
+  const resolvedProject = project === undefined ? currentProject : project;
+  const resolvedProjectLabel =
+    projectLabel ??
+    (resolvedProject === 'all'
+      ? 'All projects'
+      : resolvedProject
+        ? `Project · ${resolvedProject}`
+        : 'Project · default');
   const {
     data: localImagesData,
     isLoading,
     isValidating,
-  } = useImages(currentProject);
+  } = useImages(resolvedProject);
   const [userAddedRemoteServers, setUserAddedRemoteServers] = useState<
     RemoteServer[]
   >([]);
@@ -124,7 +144,7 @@ export default function ImageSelector({
     const map = new Map<string, RemoteServer>();
     localImagesData.forEach((image: Image) => {
       const server = image.update_source?.server;
-      if (!server) return;
+      if (!server || image.update_source?.protocol !== 'simplestreams') return;
       const normalized = normalizeRemoteURL(server);
       if (!normalized || map.has(normalized)) return;
       map.set(normalized, {
@@ -186,8 +206,54 @@ export default function ImageSelector({
     const allImages = [...localImages, ...remoteImages];
     if (!instanceType) return allImages;
     return allImages.filter((image) => image.types.includes(instanceType));
-  }, [localImages, remoteImages, instanceType]);
-  const selectedImageId = selectedImage?.id ?? null;
+  }, [instanceType, localImages, remoteImages]);
+  const defaultMatchedImage = useMemo(() => {
+    if (!localImages.length || !defaultSelection) {
+      return null;
+    }
+
+    const normalizedAlias = defaultSelection.alias?.trim().toLowerCase();
+    const normalizedDescription = defaultSelection.description
+      ?.trim()
+      .toLowerCase();
+
+    return (
+      localImages.find(
+        (image) =>
+          defaultSelection.fingerprint &&
+          image.fingerprint === defaultSelection.fingerprint,
+      ) ??
+      localImages.find((image) => {
+        if (!normalizedAlias) return false;
+        const labels = [image.label, image.os]
+          .filter(Boolean)
+          .map((value) => value!.trim().toLowerCase());
+        return labels.some((value) => value === normalizedAlias);
+      }) ??
+      localImages.find((image) => {
+        if (!normalizedDescription) return false;
+        const haystacks = [
+          image.label,
+          image.os,
+          [image.os, image.release].filter(Boolean).join(' '),
+        ]
+          .filter(Boolean)
+          .map((value) => value!.trim().toLowerCase());
+        return haystacks.some((value) => normalizedDescription.includes(value));
+      }) ??
+      null
+    );
+  }, [defaultSelection, localImages]);
+  const displayedImage = selectedImage ?? defaultMatchedImage;
+  const selectedImageId = displayedImage?.id ?? null;
+
+  useEffect(() => {
+    if (selectedImage || !defaultMatchedImage) {
+      return;
+    }
+
+    onSelect(defaultMatchedImage);
+  }, [defaultMatchedImage, onSelect, selectedImage]);
 
   const handleSelect = useCallback(
     (image: SelectableImage) => {
@@ -232,27 +298,27 @@ export default function ImageSelector({
           const image = row.original as SelectableImage;
           return (
             <div className="flex min-w-0 flex-col gap-0.5">
-              <div className="flex items-center gap-2 min-w-0">
-                <span className="font-semibold truncate" title={image.os}>
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="truncate font-semibold" title={image.os}>
                   {image.os ?? 'Unknown OS'}
                   {image.release ? ` ${image.release}` : ''}
                 </span>
                 <Badge
                   variant={image.local ? 'secondary' : 'outline'}
-                  className="text-[10px] uppercase shrink-0"
+                  className="shrink-0 text-[10px] uppercase"
                 >
                   {image.local ? 'Local' : 'Remote'}
                 </Badge>
               </div>
               <span
-                className="text-xs text-muted-foreground truncate"
+                className="truncate text-xs text-muted-foreground"
                 title={image.label}
               >
                 {image.label}
               </span>
               {!image.local && image.remote?.server ? (
                 <span
-                  className="text-[10px] text-muted-foreground truncate"
+                  className="truncate text-[10px] text-muted-foreground"
                   title={formatSource(image.remote.server)}
                 >
                   {formatSource(image.remote.server)}
@@ -298,44 +364,40 @@ export default function ImageSelector({
   );
 
   return (
-    <div className="mt-2 space-y-4 flex flex-col min-h-0">
+    <div className="mt-2 flex h-full min-h-0 flex-col space-y-4 overflow-hidden">
       {isLoading ? <Spinner className="mx-auto my-6" /> : null}
       {!isLoading ? (
         <>
-          <div className="rounded-md border bg-muted/30 p-3 text-sm shrink-0">
-            {selectedImage ? (
+          <div className="shrink-0 rounded-md border bg-muted/30 p-3 text-sm">
+            {displayedImage ? (
               <>
                 <p className="font-medium">
-                  {selectedImage.os ?? 'Unknown OS'}
-                  {selectedImage.release ? ` · ${selectedImage.release}` : ''}
-                </p>
-                <p className="text-muted-foreground text-xs">
-                  {selectedImage.label}
+                  {displayedImage.os ?? 'Unknown OS'}
+                  {displayedImage.release ? ` · ${displayedImage.release}` : ''}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {selectedImage.remote
+                  {displayedImage.label}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {displayedImage.remote
                     ? `${formatProtocol(
-                        selectedImage.remote.protocol,
-                      )} · ${formatSource(selectedImage.remote.server)}`
+                        displayedImage.remote.protocol,
+                      )} · ${formatSource(displayedImage.remote.server)}`
                     : 'Local image'}
                 </p>
               </>
             ) : (
-              <p className="text-muted-foreground">
-                Select an image to define the instance base.
-              </p>
+              <p className="text-muted-foreground">{emptyDescription}</p>
             )}
           </div>
-          <div className="flex flex-wrap items-center gap-3 shrink-0">
+          <div className="shrink-0 flex flex-wrap items-center gap-3">
             <div>
-              <p className="font-medium text-md my-auto">Available Images</p>
+              <p className="my-auto text-md font-medium">Available Images</p>
               <p className="text-xs text-muted-foreground">
-                {currentProject === 'all'
-                  ? 'All projects'
-                  : `Project · ${currentProject}`}
+                {resolvedProjectLabel}
               </p>
             </div>
-            <div className="sm:ml-auto flex flex-wrap items-center gap-2 w-full sm:w-fit">
+            <div className="flex w-full flex-wrap items-center gap-2 sm:ml-auto sm:w-fit">
               <Input
                 placeholder="Search images..."
                 value={stringFilter}
@@ -356,7 +418,7 @@ export default function ImageSelector({
                     </DialogDescription>
                   </DialogHeader>
                   <Label htmlFor="remoteProtocol">Remote Type</Label>
-                  <div className="flex gap-2 -mt-2" id="remoteProtocol">
+                  <div className="-mt-2 flex gap-2" id="remoteProtocol">
                     <Select
                       value={remoteProtocol}
                       onValueChange={(value) =>
@@ -409,12 +471,12 @@ export default function ImageSelector({
             </div>
           </div>
           <div
-            className={`mt-2 flex-1 min-h-0 overflow-hidden ${
+            className={`mt-2 min-h-0 flex-1 overflow-hidden ${
               isValidating || loadingRemotes ? 'animate-pulse' : ''
             }`}
           >
             <DataTable
-              className="h-full [&>div]:h-full [&>div]:overflow-auto"
+              className="h-full [&>div]:h-full [&>div]:overflow-hidden [&>div>div]:h-full"
               stringFilter={stringFilter}
               cols={columns}
               data={images}
@@ -422,7 +484,7 @@ export default function ImageSelector({
               onRowClick={handleRowClick}
               getRowClassName={(row) =>
                 (row.original as SelectableImage).id === selectedImageId
-                  ? 'bg-muted/30'
+                  ? 'bg-accent/40 hover:bg-accent/40'
                   : ''
               }
             />

--- a/app/(main)/_components/image-selector.tsx
+++ b/app/(main)/_components/image-selector.tsx
@@ -82,6 +82,7 @@ export default function ImageSelector({
   projectLabel,
   emptyDescription = 'Select an image to define the instance base.',
   defaultSelection,
+  disableAutoSelect = false,
 }: {
   selectedImage: SelectableImage | null;
   onSelect: (image: SelectableImage) => void;
@@ -94,6 +95,7 @@ export default function ImageSelector({
     alias?: string | null;
     description?: string | null;
   };
+  disableAutoSelect?: boolean;
 }) {
   const { currentProject } = use(ProjectsContext);
   const resolvedProject = project === undefined ? currentProject : project;
@@ -248,12 +250,12 @@ export default function ImageSelector({
   const selectedImageId = displayedImage?.id ?? null;
 
   useEffect(() => {
-    if (selectedImage || !defaultMatchedImage) {
+    if (disableAutoSelect || selectedImage || !defaultMatchedImage) {
       return;
     }
 
     onSelect(defaultMatchedImage);
-  }, [defaultMatchedImage, onSelect, selectedImage]);
+  }, [defaultMatchedImage, disableAutoSelect, onSelect, selectedImage]);
 
   const handleSelect = useCallback(
     (image: SelectableImage) => {

--- a/app/(main)/_components/project-dialog.tsx
+++ b/app/(main)/_components/project-dialog.tsx
@@ -8,7 +8,7 @@ import { mutate } from 'swr';
 import z from 'zod';
 import Editor from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
-import { Code2Icon } from 'lucide-react';
+import { CodeXmlIcon } from 'lucide-react';
 
 import {
   createProject,
@@ -462,21 +462,23 @@ export default function ProjectDialog({ open, onOpenChange, mode, project }: Pro
                 </TabsContent>
               </Tabs>
             </div>
-              <DialogFooter className="mt-4 shrink-0 border-t pt-4">
-              <Button type="button" variant="outline" onClick={toggleYamlEditor}>
-                <Code2Icon className="mr-2 h-4 w-4" />
-                {showYamlEditor ? 'Back to form' : 'Edit YAML'}
-              </Button>
-              <Button type="submit" disabled={!isFormValid}>
-                {isSubmitting ? (
-                  <>
-                    <Spinner className="mr-2 h-4 w-4" />
-                    {copy.submittingLabel}
-                  </>
-                ) : (
-                  copy.submitLabel
-                )}
-              </Button>
+            <DialogFooter className="mt-4 shrink-0 border-t pt-4">
+              <div className="flex w-full items-center justify-between">
+                <Button type="button" variant="outline" onClick={toggleYamlEditor}>
+                  <CodeXmlIcon className="mr-2 size-4" />
+                  {showYamlEditor ? 'Back to Wizard' : 'Edit YAML'}
+                </Button>
+                <Button type="submit" disabled={!isFormValid}>
+                  {isSubmitting ? (
+                    <>
+                      <Spinner className="mr-2 h-4 w-4" />
+                      {copy.submittingLabel}
+                    </>
+                  ) : (
+                    copy.submitLabel
+                  )}
+                </Button>
+              </div>
             </DialogFooter>
           </form>
         </Form>

--- a/app/(main)/instance/_components/instance-actions-menu.tsx
+++ b/app/(main)/instance/_components/instance-actions-menu.tsx
@@ -593,7 +593,7 @@ export function InstanceActionsMenu({
           </Button>
           <Button
             loading={busyAction === 'rebuild'}
-            disabled={Boolean(sourceYamlError)}
+            disabled={Boolean(sourceYamlError) || (rebuildMode === 'image' && !selectedImage && !yamlSourceOverride)}
             onClick={() => void handleRebuild()}
           >
             Rebuild instance

--- a/app/(main)/instance/_components/instance-actions-menu.tsx
+++ b/app/(main)/instance/_components/instance-actions-menu.tsx
@@ -95,7 +95,7 @@ export function InstanceActionsMenu({
   }, [handleClose, router]);
 
   const dialogContentClassName = cn(
-    'flex w-full flex-col overflow-hidden transition-[width,max-width,height,max-height] duration-200 ease-out motion-reduce:transition-none',
+    'flex w-full flex-col overflow-hidden',
     view === 'configuration' || view === 'devices' || view === 'rebuild'
       ? 'h-[90vh] max-h-[90vh] sm:max-w-6xl'
       : view === 'menu'

--- a/app/(main)/instance/_components/instance-actions-menu.tsx
+++ b/app/(main)/instance/_components/instance-actions-menu.tsx
@@ -2,57 +2,48 @@
 
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
+import { IconSettings } from '@tabler/icons-react';
 import {
-  ArrowLeftIcon,
-  CodeXmlIcon,
-  PackageIcon,
+  CopyPlusIcon,
+  HardDriveIcon,
   RefreshCcwDotIcon,
   Settings2Icon,
+  SquaresIntersectIcon,
   Trash2Icon,
   WrenchIcon,
 } from 'lucide-react';
 
 import { OSLogo } from '@/app/_components/OSLogo';
-import ImageSelector, {
-  type SelectableImage,
-} from '@/app/(main)/_components/image-selector';
-import { useStoragePools } from '@/app/(main)/_hooks/storagePools';
-import { fromYaml, toYaml } from '@/app/(main)/_lib/yaml';
-import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
-import { Badge } from 'ui-web/components/badge';
 import { Button } from 'ui-web/components/button';
-import { Checkbox } from 'ui-web/components/checkbox';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from 'ui-web/components/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from 'ui-web/components/select';
-import {
-  canDeleteInstance,
-  deleteInstance,
-  isInstanceDeleteProtected,
-  isInstanceRunning,
-  rebuildInstance,
-  repairInstance,
-  type AdvancedInstanceRebuildSource,
-} from '../_lib/instance';
-import { SettingsYamlEditor } from './settings-yaml-editor';
-import { getBaseImage } from '../_lib/utils';
+import { cn } from 'ui-web/lib/utils';
 import type { Instance } from '../../instances/_lib/instances.d';
+import { getBaseImage } from '../_lib/utils';
+import Clone from './management/clone';
+import Configuration from './management/configuration';
+import Delete from './management/delete';
+import Devices from './management/devices';
+import Profiles from './management/profiles';
+import Rebuild from './management/rebuild';
+import Repair from './management/repair';
+import { useStoragePools } from '@/app/(main)/_hooks/storagePools';
 
-type ActionView = 'menu' | 'delete' | 'rebuild' | 'repair';
-type RebuildMode = 'image' | 'empty';
+type ActionView =
+  | 'menu'
+  | 'devices'
+  | 'configuration'
+  | 'profiles'
+  | 'rebuild'
+  | 'clone'
+  | 'repair'
+  | 'delete';
 
 export function InstanceActionsMenu({
   instance,
@@ -67,580 +58,55 @@ export function InstanceActionsMenu({
   const { data: storagePools } = useStoragePools();
   const [open, setOpen] = React.useState(false);
   const [view, setView] = React.useState<ActionView>('menu');
-  const [busyAction, setBusyAction] = React.useState<ActionView | null>(null);
-  const [actionError, setActionError] = React.useState<string | null>(null);
-  const [rebuildMode, setRebuildMode] = React.useState<RebuildMode>('image');
-  const [forceDelete, setForceDelete] = React.useState(false);
-  const [selectedImage, setSelectedImage] =
-    React.useState<SelectableImage | null>(null);
-  const [showSourceYamlEditor, setShowSourceYamlEditor] = React.useState(false);
-  const [sourceYamlContent, setSourceYamlContent] = React.useState('');
-  const [sourceYamlError, setSourceYamlError] = React.useState<string | null>(null);
-  const [yamlSourceOverride, setYamlSourceOverride] =
-    React.useState<AdvancedInstanceRebuildSource | null>(null);
 
   const rootDiskPoolName =
     instance.expanded_devices?.root?.pool ?? instance.devices?.root?.pool ?? null;
   const rootDiskPool =
     storagePools?.find((pool) => pool.name === rootDiskPoolName) ?? null;
-  const isRunning = isInstanceRunning(instance);
-  const isDeleteProtected = isInstanceDeleteProtected(instance);
-  const canDelete = canDeleteInstance(instance);
-  const canForceDelete = isRunning && !isDeleteProtected;
   const canRepair =
     instance.type === 'virtual-machine' &&
     rootDiskPool?.driver === 'lvm' &&
     (rootDiskPool.locations?.length ?? 0) > 1;
-  const isBusy = busyAction !== null;
+  const status = instance.status?.toLowerCase();
+  const isRunning = status === 'running' || status === 'started';
+  const isStopped = status === 'stopped';
 
   React.useEffect(() => {
-    if (open) {
-      return;
+    if (!open) {
+      setView('menu');
     }
-
-    setView('menu');
-    setBusyAction(null);
-    setActionError(null);
-    setRebuildMode('image');
-    setForceDelete(false);
-    setSelectedImage(null);
-    setShowSourceYamlEditor(false);
-    setSourceYamlContent('');
-    setSourceYamlError(null);
-    setYamlSourceOverride(null);
   }, [open]);
 
-  const projectLabel = instance.project
-    ? `Project · ${instance.project}`
-    : 'Project · default';
+  const handleClose = React.useCallback(() => {
+    setOpen(false);
+    setView('menu');
+  }, []);
 
-  const getSelectedImageSource =
-    React.useCallback((): AdvancedInstanceRebuildSource => {
-      if (!selectedImage) {
-        throw new Error('Select an image before rebuilding this instance.');
-      }
+  const handleMutateAndClose = React.useCallback(async () => {
+    handleClose();
+    await onMutate();
+  }, [handleClose, onMutate]);
 
-      if (selectedImage.local && selectedImage.fingerprint) {
-        return {
-          type: 'image',
-          fingerprint: selectedImage.fingerprint,
-        };
-      }
+  const handleDeleteDone = React.useCallback(async () => {
+    handleClose();
+    React.startTransition(() => {
+      router.push('/instances');
+    });
+  }, [handleClose, router]);
 
-      if (selectedImage.remote?.alias && selectedImage.remote?.server) {
-        return {
-          type: 'image',
-          alias: selectedImage.remote.alias,
-          server: selectedImage.remote.server,
-          mode: 'pull',
-          protocol: selectedImage.remote.protocol,
-        };
-      }
-
-      throw new Error('The selected image is missing the data needed for rebuild.');
-    }, [selectedImage]);
-
-  const getRebuildSource = React.useCallback((): AdvancedInstanceRebuildSource => {
-    if (yamlSourceOverride) {
-      return yamlSourceOverride;
-    }
-
-    if (rebuildMode === 'empty') {
-      return { type: 'none' };
-    }
-
-    return getSelectedImageSource();
-  }, [getSelectedImageSource, rebuildMode, yamlSourceOverride]);
-
-  const updateYamlSourceOverride = React.useCallback(
-    (
-      nextSource: AdvancedInstanceRebuildSource | null,
-      skipContentUpdate = false,
-    ) => {
-      setYamlSourceOverride(nextSource);
-
-      if (!nextSource) {
-        setSourceYamlError(null);
-        return;
-      }
-
-      if (!skipContentUpdate) {
-        setSourceYamlContent(
-          toYaml(nextSource as unknown as Record<string, unknown>),
-        );
-      }
-      setSourceYamlError(null);
-    },
-    [],
-  );
-
-  const syncSelectedImageFromSource = React.useCallback(
-    (nextSource: AdvancedInstanceRebuildSource) => {
-      if (nextSource.type !== 'image') {
-        setSelectedImage(null);
-        return;
-      }
-
-      if (nextSource.fingerprint) {
-        setSelectedImage((current) =>
-          current?.fingerprint === nextSource.fingerprint
-            ? current
-            : null,
-        );
-        return;
-      }
-
-      if (nextSource.alias && nextSource.server) {
-        setSelectedImage((current) =>
-          current?.remote?.alias === nextSource.alias &&
-          current?.remote?.server === nextSource.server
-            ? current
-            : null,
-        );
-        return;
-      }
-
-      setSelectedImage(null);
-    },
-    [],
-  );
-
-  const handleSourceYamlChange = React.useCallback(
-    (value: string | undefined) => {
-      const nextValue = value ?? '';
-      setSourceYamlContent(nextValue);
-
-      try {
-        const parsed = fromYaml(nextValue);
-        if (!parsed || typeof parsed !== 'object') {
-          throw new Error('Invalid source YAML.');
-        }
-        const parsedSource = parsed as Record<string, unknown>;
-        const type = parsedSource.type;
-
-        if (type !== 'image' && type !== 'none') {
-          throw new Error('Source YAML must include type: image or type: none.');
-        }
-
-        if (type === 'none') {
-          const nextSource: AdvancedInstanceRebuildSource = { type: 'none' };
-          setRebuildMode('empty');
-          updateYamlSourceOverride(nextSource, true);
-          syncSelectedImageFromSource(nextSource);
-          return;
-        }
-
-        const fingerprint =
-          typeof parsedSource.fingerprint === 'string' &&
-          parsedSource.fingerprint.trim()
-            ? parsedSource.fingerprint.trim()
-            : undefined;
-        const alias =
-          typeof parsedSource.alias === 'string' && parsedSource.alias.trim()
-            ? parsedSource.alias.trim()
-            : undefined;
-        const server =
-          typeof parsedSource.server === 'string' && parsedSource.server.trim()
-            ? parsedSource.server.trim()
-            : undefined;
-        const mode = parsedSource.mode;
-        const protocol = parsedSource.protocol;
-
-        if (!fingerprint && !(alias && server)) {
-          throw new Error(
-            'Image source YAML must include fingerprint or both alias and server.',
-          );
-        }
-
-        if (mode !== undefined && mode !== 'pull') {
-          throw new Error('Only mode: pull is supported for rebuild sources.');
-        }
-
-        if (
-          protocol !== undefined &&
-          protocol !== 'simplestreams' &&
-          protocol !== 'oci'
-        ) {
-          throw new Error(
-            'protocol must be either simplestreams or oci when provided.',
-          );
-        }
-
-        const nextSource: AdvancedInstanceRebuildSource = {
-          type: 'image',
-          ...(fingerprint ? { fingerprint } : {}),
-          ...(alias ? { alias } : {}),
-          ...(server ? { server } : {}),
-          ...(mode === 'pull' ? { mode } : {}),
-          ...(protocol ? { protocol } : {}),
-        };
-
-        setRebuildMode('image');
-        updateYamlSourceOverride(nextSource, true);
-        syncSelectedImageFromSource(nextSource);
-      } catch (error) {
-        setSourceYamlError(
-          error instanceof Error ? error.message : 'Invalid source YAML.',
-        );
-      }
-    },
-    [syncSelectedImageFromSource, updateYamlSourceOverride],
-  );
-
-  const handleToggleSourceYamlEditor = React.useCallback(() => {
-    if (!showSourceYamlEditor) {
-      try {
-        const currentSource = getRebuildSource();
-        setSourceYamlContent(
-          toYaml(currentSource as unknown as Record<string, unknown>),
-        );
-        setSourceYamlError(null);
-      } catch {
-        setSourceYamlContent(
-          toYaml({ type: rebuildMode } as unknown as Record<string, unknown>),
-        );
-      }
-    }
-
-    setShowSourceYamlEditor((current) => !current);
-  }, [getRebuildSource, rebuildMode, showSourceYamlEditor]);
-
-  const handleRebuildModeChange = React.useCallback(
-    (nextMode: RebuildMode) => {
-      setRebuildMode(nextMode);
-      setSourceYamlError(null);
-
-      if (nextMode === 'empty') {
-        const emptySource: AdvancedInstanceRebuildSource = { type: 'none' };
-        updateYamlSourceOverride(emptySource);
-        setSourceYamlContent(toYaml(emptySource as Record<string, unknown>));
-        return;
-      }
-
-      updateYamlSourceOverride(null);
-
-      try {
-        const imageSource = getSelectedImageSource();
-        setSourceYamlContent(toYaml(imageSource as Record<string, unknown>));
-      } catch {
-        setSourceYamlContent(toYaml({ type: 'image' } as Record<string, unknown>));
-      }
-    },
-    [getSelectedImageSource, updateYamlSourceOverride],
-  );
-
-  const handleRebuildImageSelect = React.useCallback(
-    (image: SelectableImage) => {
-      setSelectedImage(image);
-      updateYamlSourceOverride(null);
-      setSourceYamlError(null);
-    },
-    [updateYamlSourceOverride],
-  );
-
-  const handleDelete = async () => {
-    if (!canDelete) {
-      if (!canForceDelete || !forceDelete) {
-        return;
-      }
-    }
-
-    try {
-      setActionError(null);
-      setBusyAction('delete');
-      await deleteInstance(instance, canForceDelete && forceDelete);
-      setOpen(false);
-      React.startTransition(() => {
-        router.push('/instances');
-      });
-    } catch (error) {
-      setActionError(
-        error instanceof Error ? error.message : 'Unable to delete instance.',
-      );
-    } finally {
-      setBusyAction(null);
-    }
-  };
-
-  const handleRebuild = async () => {
-    try {
-      setActionError(null);
-      setBusyAction('rebuild');
-      const source = getRebuildSource();
-      await rebuildInstance({ instance, source });
-      setOpen(false);
-      await onMutate();
-    } catch (error) {
-      setActionError(
-        error instanceof Error ? error.message : 'Unable to rebuild instance.',
-      );
-    } finally {
-      setBusyAction(null);
-    }
-  };
-
-  const handleRepair = async () => {
-    try {
-      setActionError(null);
-      setBusyAction('repair');
-      await repairInstance({
-        instance,
-        action: 'rebuild-config-volume',
-      });
-      setOpen(false);
-      await onMutate();
-    } catch (error) {
-      setActionError(
-        error instanceof Error ? error.message : 'Unable to repair instance.',
-      );
-    } finally {
-      setBusyAction(null);
-    }
-  };
-
-  const renderStatusIndicator = () => {
-    const status = instance.status?.toLowerCase();
-
-    if (status === 'running' || status === 'started') {
-      return (
-        <span className="absolute -right-1 -bottom-1 flex h-4 w-4">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
-          <span className="relative inline-flex h-4 w-4 rounded-full bg-green-500" />
-        </span>
-      );
-    }
-
-    if (status === 'stopped') {
-      return (
-        <span className="absolute -right-1 -bottom-1 flex h-4 w-4">
-          <span className="relative inline-flex h-4 w-4 rounded-full bg-red-500" />
-        </span>
-      );
-    }
-
-    return (
-      <span className="absolute -right-1 -bottom-1 flex h-4 w-4">
-        <span className="relative inline-flex h-4 w-4 rounded-full bg-gray-400" />
-      </span>
-    );
-  };
-
-  const renderMenu = () => (
-    <div className="grid gap-3">
-      <ActionCard
-        icon={<RefreshCcwDotIcon className="size-4" />}
-        title="Rebuild instance"
-        description="Recreate the instance from a selected image or as empty."
-        onClick={() => setView('rebuild')}
-      />
-      {canRepair ? (
-        <ActionCard
-          icon={<WrenchIcon className="size-4" />}
-          title="Repair instance"
-          description="Run the supported low-level repair action for this instance."
-          onClick={() => setView('repair')}
-        />
-      ) : null}
-      <ActionCard
-        icon={<Trash2Icon className="size-4 text-destructive" />}
-        title="Delete instance"
-        description="Permanently remove this instance and all of its data."
-        onClick={() => setView('delete')}
-      />
-    </div>
-  );
-
-  const renderDeleteView = () => (
-    <div className="space-y-4">
-      <div className="rounded-md border border-destructive/20 bg-destructive/5 p-4 text-sm">
-        This action cannot be undone. This will permanently delete{' '}
-        <strong>{instance.name}</strong> and all of its data.
-      </div>
-
-      {isRunning ? (
-        <Alert>
-          <AlertTitle>Stop the instance first</AlertTitle>
-          <AlertDescription>
-            Running instances must be stopped before deletion. You can force a
-            stop first and then continue with deletion from here.
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {isDeleteProtected ? (
-        <Alert>
-          <AlertTitle>Delete protection is enabled</AlertTitle>
-          <AlertDescription>
-            Disable <code>security.protection.delete</code> before deleting this
-            instance.
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {!isRunning && !isDeleteProtected ? (
-        <p className="text-sm text-muted-foreground">
-          The delete request will be sent immediately and progress will be
-          tracked through the existing operation events.
-        </p>
-      ) : null}
-
-      {canForceDelete ? (
-        <label className="flex items-start gap-3 rounded-md border bg-muted/20 p-3 text-sm">
-          <Checkbox
-            checked={forceDelete}
-            onCheckedChange={(checked) => setForceDelete(checked === true)}
-            disabled={isBusy}
-            aria-label="Force stop before deleting"
-          />
-          <span className="space-y-1">
-            <span className="block font-medium">Force stop before delete</span>
-            <span className="block text-muted-foreground">
-              Stop the running instance with force, wait for it to stop, then
-              delete it.
-            </span>
-          </span>
-        </label>
-      ) : null}
-
-      <DialogFooter>
-        <Button variant="outline" onClick={() => setView('menu')} disabled={isBusy}>
-          Back
-        </Button>
-        <Button
-          variant="destructive"
-          loading={busyAction === 'delete'}
-          disabled={(!canDelete && !(canForceDelete && forceDelete)) || isBusy}
-          onClick={() => void handleDelete()}
-        >
-          {canForceDelete && forceDelete ? 'Force stop and delete' : 'Delete instance'}
-        </Button>
-      </DialogFooter>
-    </div>
-  );
-
-  const renderRebuildView = () => (
-    <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)_auto] gap-4 overflow-hidden">
-      {!showSourceYamlEditor ? (
-        <div className="grid gap-2">
-          <p className="text-sm font-medium">Rebuild source</p>
-          <Select
-            value={rebuildMode}
-            onValueChange={(value) =>
-              handleRebuildModeChange(value as RebuildMode)
-            }
-            disabled={isBusy}
-          >
-            <SelectTrigger className="w-full sm:w-64">
-              <SelectValue placeholder="Select rebuild source" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="image">Image</SelectItem>
-              <SelectItem value="empty">Empty rebuild</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      ) : null}
-
-      {rebuildMode === 'image' ? (
-        <div className="min-h-0 overflow-hidden">
-          {showSourceYamlEditor ? (
-            <div className="h-[24rem] min-h-[24rem] overflow-hidden">
-              <SettingsYamlEditor
-                value={sourceYamlContent}
-                error={sourceYamlError}
-                onChange={handleSourceYamlChange}
-              />
-            </div>
-          ) : (
-            <ImageSelector
-              selectedImage={selectedImage}
-              onSelect={handleRebuildImageSelect}
-              instanceType={
-                instance.type === 'virtual-machine'
-                  ? 'virtual-machine'
-                  : 'container'
-              }
-              project={instance.project ?? null}
-              projectLabel={projectLabel}
-              emptyDescription="Select the image to use for the rebuild."
-              defaultSelection={{
-                fingerprint:
-                  instance.expanded_config?.['volatile.base_image'] ??
-                  instance.config?.['volatile.base_image'] ??
-                  null,
-                alias: instance.config?.['image.alias'] ?? null,
-                description: instance.config?.['image.description'] ?? null,
-              }}
-              disableAutoSelect={showSourceYamlEditor}
-            />
-          )}
-        </div>
-      ) : (
-        <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
-          An empty rebuild recreates the instance without selecting an image
-          source.
-        </div>
-      )}
-
-      <div className="flex flex-wrap items-center gap-3 border-t pt-4">
-        <div>
-          {rebuildMode === 'image' ? (
-            <Button
-              variant="outline"
-              onClick={handleToggleSourceYamlEditor}
-              disabled={isBusy}
-            >
-              {showSourceYamlEditor ? (
-                <PackageIcon className="mr-2 h-4 w-4" />
-              ) : (
-                <CodeXmlIcon className="mr-2 h-4 w-4" />
-              )}
-              {showSourceYamlEditor ? 'Back to image list' : 'Edit YAML'}
-            </Button>
-          ) : null}
-        </div>
-        <div className="ml-auto flex flex-wrap items-center gap-2">
-          <Button
-            variant="outline"
-            onClick={() => setView('menu')}
-            disabled={isBusy}
-          >
-            Back
-          </Button>
-          <Button
-            loading={busyAction === 'rebuild'}
-            disabled={Boolean(sourceYamlError) || (rebuildMode === 'image' && !selectedImage && !yamlSourceOverride)}
-            onClick={() => void handleRebuild()}
-          >
-            Rebuild instance
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-
-  const renderRepairView = () => (
-    <div className="space-y-4">
-      <div className="rounded-md border bg-muted/30 p-4 text-sm">
-        <div className="flex items-center gap-2">
-          <span className="font-medium">Supported action</span>
-          <Badge variant="outline">rebuild-config-volume</Badge>
-        </div>
-        <p className="mt-2 text-muted-foreground">
-          This triggers the currently supported low-level repair action exposed
-          by Incus for this instance.
-        </p>
-      </div>
-
-      <DialogFooter>
-        <Button variant="outline" onClick={() => setView('menu')} disabled={isBusy}>
-          Back
-        </Button>
-        <Button loading={busyAction === 'repair'} onClick={() => void handleRepair()}>
-          Run repair
-        </Button>
-      </DialogFooter>
-    </div>
+  const dialogContentClassName = cn(
+    'flex w-full flex-col overflow-hidden transition-[width,max-width,height,max-height] duration-200 ease-out motion-reduce:transition-none',
+    view === 'configuration' || view === 'devices' || view === 'rebuild'
+      ? 'h-[90vh] max-h-[90vh] sm:max-w-6xl'
+      : view === 'menu'
+        ? 'max-h-[90vh] sm:max-w-4xl'
+        : view === 'clone'
+          ? 'max-h-[90vh] sm:max-w-2xl'
+          : view === 'profiles'
+            ? 'max-h-[90vh] sm:max-w-2xl'
+            : view === 'delete'
+              ? 'max-h-[90vh] sm:max-w-2xl'
+              : 'max-h-[90vh] sm:max-w-2xl',
   );
 
   return (
@@ -649,73 +115,205 @@ export function InstanceActionsMenu({
         <Button
           type="button"
           variant="ghost"
+          size="icon"
           disabled={disabled}
-          className="group relative h-16 w-16 rounded-lg border bg-muted p-0 hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          aria-label="Open instance actions"
+          className="group relative h-16 w-16 rounded-lg border bg-muted p-0 hover:bg-muted"
+          aria-label={`Manage instance ${instance.name}`}
         >
           <OSLogo brand={getBaseImage(instance)} className="size-8" />
-          <span className="absolute inset-0 rounded-lg bg-background/75 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
-          <Settings2Icon className="absolute size-5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
-          {renderStatusIndicator()}
+          <span className="absolute inset-0 rounded-lg bg-background/0 transition-colors group-hover:bg-background/10 group-focus-visible:bg-background/10" />
+          <span className="absolute -right-1 -bottom-1 size-3.75" aria-hidden="true">
+            {isRunning ? (
+              <>
+                <span className="absolute inset-0 rounded-full bg-emerald-500/20 scale-[1.35]" />
+                <span className="absolute inset-0 rounded-full bg-emerald-500/35 [animation:status-halo-pulse_2.8s_ease-out_infinite]" />
+              </>
+            ) : null}
+            <span
+              className={cn(
+                'absolute inset-0 rounded-full border-2 border-background shadow-[0_0_0_1px_rgba(0,0,0,0.08)] transition-transform group-hover:scale-105',
+                isRunning && 'bg-emerald-500',
+                isStopped && 'bg-red-400',
+                !isRunning && !isStopped && 'bg-amber-400',
+              )}
+            />
+          </span>
+          <span className="absolute top-1 right-1 rounded-full border bg-background/95 p-1 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+            <Settings2Icon className="size-3" />
+          </span>
         </Button>
       </DialogTrigger>
-      <DialogContent className="flex max-h-[85vh] flex-col overflow-hidden sm:max-w-4xl">
-        <DialogHeader className="shrink-0">
-          <div className="flex items-center gap-2">
-            {view !== 'menu' ? (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => setView('menu')}
-                disabled={isBusy}
-                aria-label="Back to actions menu"
-              >
-                <ArrowLeftIcon className="size-4" />
-              </Button>
-            ) : null}
-            <DialogTitle>{getDialogTitle(view, instance.name)}</DialogTitle>
-          </div>
+      <DialogContent className={dialogContentClassName}>
+        <DialogHeader>
+          <DialogTitle>{getDialogTitle(view, instance.name)}</DialogTitle>
           <DialogDescription>
             {getDialogDescription(view, instance.name)}
           </DialogDescription>
         </DialogHeader>
 
-        {actionError ? (
-          <Alert variant="destructive">
-            <AlertTitle>Action failed</AlertTitle>
-            <AlertDescription>{actionError}</AlertDescription>
-          </Alert>
-        ) : null}
+        <div
+          className={cn(
+            'min-h-0 flex-1 pr-1',
+            view === 'menu' || view === 'clone' || view === 'delete' || view === 'repair' || view === 'profiles'
+              ? 'overflow-y-auto'
+              : 'overflow-hidden',
+          )}
+        >
+          {view === 'menu' ? (
+            <ActionMenu canRepair={canRepair} onSelect={setView} />
+          ) : null}
 
-        {view === 'menu' ? renderMenu() : null}
-        {view === 'delete' ? renderDeleteView() : null}
-        {view === 'rebuild' ? renderRebuildView() : null}
-        {view === 'repair' && canRepair ? renderRepairView() : null}
+          {view === 'devices' ? (
+            <Devices
+              instance={instance}
+              onMutate={onMutate}
+              onBack={() => setView('menu')}
+            />
+          ) : null}
+
+          {view === 'configuration' ? (
+            <Configuration
+              instance={instance}
+              onMutate={onMutate}
+              onBack={() => setView('menu')}
+            />
+          ) : null}
+
+          {view === 'profiles' ? (
+            <Profiles
+              instance={instance}
+              onMutate={onMutate}
+              onBack={() => setView('menu')}
+            />
+          ) : null}
+
+          {view === 'rebuild' ? (
+            <Rebuild
+              instance={instance}
+              onBack={() => setView('menu')}
+              onDone={handleMutateAndClose}
+            />
+          ) : null}
+
+          {view === 'clone' ? (
+            <Clone
+              instance={instance}
+              onBack={() => setView('menu')}
+              onDone={handleMutateAndClose}
+            />
+          ) : null}
+
+          {view === 'repair' ? (
+            <Repair
+              instance={instance}
+              onBack={() => setView('menu')}
+              onDone={handleMutateAndClose}
+            />
+          ) : null}
+
+          {view === 'delete' ? (
+            <Delete
+              instance={instance}
+              onBack={() => setView('menu')}
+              onDone={handleDeleteDone}
+            />
+          ) : null}
+        </div>
       </DialogContent>
     </Dialog>
   );
 }
 
+function ActionMenu({
+  canRepair,
+  onSelect,
+}: {
+  canRepair: boolean;
+  onSelect: (view: Exclude<ActionView, 'menu'>) => void;
+}) {
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      <ActionCard
+        title="Manage Devices"
+        description="Add, remove, and edit instance devices."
+        icon={HardDriveIcon}
+        onClick={() => onSelect('devices')}
+      />
+      <ActionCard
+        title="Edit Configuration"
+        description="Update instance configuration values and raw YAML."
+        icon={IconSettings}
+        onClick={() => onSelect('configuration')}
+      />
+      <ActionCard
+        title="Manage Profiles"
+        description="Add or remove profiles applied to this instance."
+        icon={SquaresIntersectIcon}
+        onClick={() => onSelect('profiles')}
+      />
+      <ActionCard
+        title="Clone"
+        description="Create a local copy of this instance."
+        icon={CopyPlusIcon}
+        onClick={() => onSelect('clone')}
+      />
+      {canRepair ? (
+        <ActionCard
+          title="Repair"
+          description="Run the supported low-level repair action for this instance."
+          icon={WrenchIcon}
+          onClick={() => onSelect('repair')}
+        />
+      ) : null}
+      <ActionCard
+        title="Rebuild"
+        description="Replace this instance from an image or empty source."
+        icon={RefreshCcwDotIcon}
+        onClick={() => onSelect('rebuild')}
+      />
+      <ActionCard
+        title="Delete"
+        description="Permanently remove this instance and its data."
+        icon={Trash2Icon}
+        destructive
+        onClick={() => onSelect('delete')}
+      />
+    </div>
+  );
+}
+
 function ActionCard({
-  icon,
   title,
   description,
+  icon: Icon,
+  destructive = false,
   onClick,
 }: {
-  icon: React.ReactNode;
   title: string;
   description: string;
+    icon: React.ComponentType<{ className?: string }>;
+    destructive?: boolean;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
-      className="flex w-full items-start gap-3 rounded-lg border p-4 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       onClick={onClick}
+      className={cn(
+        'flex w-full items-start gap-3 rounded-lg border bg-card p-4 text-left transition-colors hover:bg-accent/40',
+        destructive && 'border-destructive/30 hover:bg-destructive/5',
+      )}
     >
-      <span className="mt-0.5 rounded-md border bg-background p-2">{icon}</span>
+      <span
+        className={cn(
+          'rounded-md border bg-muted p-2 text-muted-foreground',
+          destructive && 'border-destructive/20 text-destructive',
+        )}
+      >
+        <Icon className="size-4" />
+      </span>
       <span className="space-y-1">
-        <span className="block font-medium">{title}</span>
+        <span className="block text-sm font-medium">{title}</span>
         <span className="block text-sm text-muted-foreground">
           {description}
         </span>
@@ -726,26 +324,44 @@ function ActionCard({
 
 function getDialogTitle(view: ActionView, instanceName: string) {
   switch (view) {
-    case 'delete':
-      return `Delete ${instanceName}`;
+    case 'devices':
+      return 'Manage Devices';
+    case 'configuration':
+      return 'Edit Configuration';
+    case 'profiles':
+      return 'Manage Profiles';
     case 'rebuild':
       return `Rebuild ${instanceName}`;
+    case 'clone':
+      return `Clone ${instanceName}`;
     case 'repair':
       return `Repair ${instanceName}`;
+    case 'delete':
+      return `Delete ${instanceName}`;
+    case 'menu':
     default:
-      return `${instanceName} actions`;
+      return 'Manage Instance';
   }
 }
 
 function getDialogDescription(view: ActionView, instanceName: string) {
   switch (view) {
-    case 'delete':
-      return 'Confirm the destructive delete action for this instance.';
+    case 'devices':
+      return `Manage the devices attached to ${instanceName}.`;
+    case 'configuration':
+      return `Edit configuration keys and YAML for ${instanceName}.`;
+    case 'profiles':
+      return `Choose which profiles are applied to ${instanceName}.`;
     case 'rebuild':
       return 'Choose how to rebuild this instance.';
+    case 'clone':
+      return 'Create a local copy of this instance.';
     case 'repair':
       return 'Run the supported repair action for this instance.';
+    case 'delete':
+      return 'Confirm the destructive delete action for this instance.';
+    case 'menu':
     default:
-      return `Manage destructive and recovery actions for ${instanceName}.`;
+      return 'Edit this instance or run advanced actions.';
   }
 }

--- a/app/(main)/instance/_components/instance-actions-menu.tsx
+++ b/app/(main)/instance/_components/instance-actions-menu.tsx
@@ -153,7 +153,10 @@ export function InstanceActionsMenu({
   }, [getSelectedImageSource, rebuildMode, yamlSourceOverride]);
 
   const updateYamlSourceOverride = React.useCallback(
-    (nextSource: AdvancedInstanceRebuildSource | null) => {
+    (
+      nextSource: AdvancedInstanceRebuildSource | null,
+      skipContentUpdate = false,
+    ) => {
       setYamlSourceOverride(nextSource);
 
       if (!nextSource) {
@@ -161,9 +164,11 @@ export function InstanceActionsMenu({
         return;
       }
 
-      setSourceYamlContent(
-        toYaml(nextSource as unknown as Record<string, unknown>),
-      );
+      if (!skipContentUpdate) {
+        setSourceYamlContent(
+          toYaml(nextSource as unknown as Record<string, unknown>),
+        );
+      }
       setSourceYamlError(null);
     },
     [],
@@ -207,7 +212,11 @@ export function InstanceActionsMenu({
 
       try {
         const parsed = fromYaml(nextValue);
-        const type = parsed.type;
+        if (!parsed || typeof parsed !== 'object') {
+          throw new Error('Invalid source YAML.');
+        }
+        const parsedSource = parsed as Record<string, unknown>;
+        const type = parsedSource.type;
 
         if (type !== 'image' && type !== 'none') {
           throw new Error('Source YAML must include type: image or type: none.');
@@ -216,25 +225,26 @@ export function InstanceActionsMenu({
         if (type === 'none') {
           const nextSource: AdvancedInstanceRebuildSource = { type: 'none' };
           setRebuildMode('empty');
-          updateYamlSourceOverride(nextSource);
+          updateYamlSourceOverride(nextSource, true);
           syncSelectedImageFromSource(nextSource);
           return;
         }
 
         const fingerprint =
-          typeof parsed.fingerprint === 'string' && parsed.fingerprint.trim()
-            ? parsed.fingerprint.trim()
+          typeof parsedSource.fingerprint === 'string' &&
+          parsedSource.fingerprint.trim()
+            ? parsedSource.fingerprint.trim()
             : undefined;
         const alias =
-          typeof parsed.alias === 'string' && parsed.alias.trim()
-            ? parsed.alias.trim()
+          typeof parsedSource.alias === 'string' && parsedSource.alias.trim()
+            ? parsedSource.alias.trim()
             : undefined;
         const server =
-          typeof parsed.server === 'string' && parsed.server.trim()
-            ? parsed.server.trim()
+          typeof parsedSource.server === 'string' && parsedSource.server.trim()
+            ? parsedSource.server.trim()
             : undefined;
-        const mode = parsed.mode;
-        const protocol = parsed.protocol;
+        const mode = parsedSource.mode;
+        const protocol = parsedSource.protocol;
 
         if (!fingerprint && !(alias && server)) {
           throw new Error(
@@ -266,7 +276,7 @@ export function InstanceActionsMenu({
         };
 
         setRebuildMode('image');
-        updateYamlSourceOverride(nextSource);
+        updateYamlSourceOverride(nextSource, true);
         syncSelectedImageFromSource(nextSource);
       } catch (error) {
         setSourceYamlError(
@@ -556,6 +566,7 @@ export function InstanceActionsMenu({
                 alias: instance.config?.['image.alias'] ?? null,
                 description: instance.config?.['image.description'] ?? null,
               }}
+              disableAutoSelect={showSourceYamlEditor}
             />
           )}
         </div>

--- a/app/(main)/instance/_components/instance-actions-menu.tsx
+++ b/app/(main)/instance/_components/instance-actions-menu.tsx
@@ -329,6 +329,15 @@ export function InstanceActionsMenu({
     [getSelectedImageSource, updateYamlSourceOverride],
   );
 
+  const handleRebuildImageSelect = React.useCallback(
+    (image: SelectableImage) => {
+      setSelectedImage(image);
+      updateYamlSourceOverride(null);
+      setSourceYamlError(null);
+    },
+    [updateYamlSourceOverride],
+  );
+
   const handleDelete = async () => {
     if (!canDelete) {
       if (!canForceDelete || !forceDelete) {
@@ -545,11 +554,7 @@ export function InstanceActionsMenu({
           ) : (
             <ImageSelector
               selectedImage={selectedImage}
-              onSelect={(image) => {
-                setSelectedImage(image);
-                updateYamlSourceOverride(null);
-                setSourceYamlError(null);
-              }}
+              onSelect={handleRebuildImageSelect}
               instanceType={
                 instance.type === 'virtual-machine'
                   ? 'virtual-machine'

--- a/app/(main)/instance/_components/instance-actions-menu.tsx
+++ b/app/(main)/instance/_components/instance-actions-menu.tsx
@@ -1,0 +1,735 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  ArrowLeftIcon,
+  CodeXmlIcon,
+  PackageIcon,
+  RefreshCcwDotIcon,
+  Settings2Icon,
+  Trash2Icon,
+  WrenchIcon,
+} from 'lucide-react';
+
+import { OSLogo } from '@/app/_components/OSLogo';
+import ImageSelector, {
+  type SelectableImage,
+} from '@/app/(main)/_components/image-selector';
+import { useStoragePools } from '@/app/(main)/_hooks/storagePools';
+import { fromYaml, toYaml } from '@/app/(main)/_lib/yaml';
+import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
+import { Badge } from 'ui-web/components/badge';
+import { Button } from 'ui-web/components/button';
+import { Checkbox } from 'ui-web/components/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui-web/components/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from 'ui-web/components/select';
+import {
+  canDeleteInstance,
+  deleteInstance,
+  isInstanceDeleteProtected,
+  isInstanceRunning,
+  rebuildInstance,
+  repairInstance,
+  type AdvancedInstanceRebuildSource,
+} from '../_lib/instance';
+import { SettingsYamlEditor } from './settings-yaml-editor';
+import { getBaseImage } from '../_lib/utils';
+import type { Instance } from '../../instances/_lib/instances.d';
+
+type ActionView = 'menu' | 'delete' | 'rebuild' | 'repair';
+type RebuildMode = 'image' | 'empty';
+
+export function InstanceActionsMenu({
+  instance,
+  disabled = false,
+  onMutate,
+}: {
+  instance: Instance;
+  disabled?: boolean;
+  onMutate: () => Promise<void>;
+}) {
+  const router = useRouter();
+  const { data: storagePools } = useStoragePools();
+  const [open, setOpen] = React.useState(false);
+  const [view, setView] = React.useState<ActionView>('menu');
+  const [busyAction, setBusyAction] = React.useState<ActionView | null>(null);
+  const [actionError, setActionError] = React.useState<string | null>(null);
+  const [rebuildMode, setRebuildMode] = React.useState<RebuildMode>('image');
+  const [forceDelete, setForceDelete] = React.useState(false);
+  const [selectedImage, setSelectedImage] =
+    React.useState<SelectableImage | null>(null);
+  const [showSourceYamlEditor, setShowSourceYamlEditor] = React.useState(false);
+  const [sourceYamlContent, setSourceYamlContent] = React.useState('');
+  const [sourceYamlError, setSourceYamlError] = React.useState<string | null>(null);
+  const [yamlSourceOverride, setYamlSourceOverride] =
+    React.useState<AdvancedInstanceRebuildSource | null>(null);
+
+  const rootDiskPoolName =
+    instance.expanded_devices?.root?.pool ?? instance.devices?.root?.pool ?? null;
+  const rootDiskPool =
+    storagePools?.find((pool) => pool.name === rootDiskPoolName) ?? null;
+  const isRunning = isInstanceRunning(instance);
+  const isDeleteProtected = isInstanceDeleteProtected(instance);
+  const canDelete = canDeleteInstance(instance);
+  const canForceDelete = isRunning && !isDeleteProtected;
+  const canRepair =
+    instance.type === 'virtual-machine' &&
+    rootDiskPool?.driver === 'lvm' &&
+    (rootDiskPool.locations?.length ?? 0) > 1;
+  const isBusy = busyAction !== null;
+
+  React.useEffect(() => {
+    if (open) {
+      return;
+    }
+
+    setView('menu');
+    setBusyAction(null);
+    setActionError(null);
+    setRebuildMode('image');
+    setForceDelete(false);
+    setSelectedImage(null);
+    setShowSourceYamlEditor(false);
+    setSourceYamlContent('');
+    setSourceYamlError(null);
+    setYamlSourceOverride(null);
+  }, [open]);
+
+  const projectLabel = instance.project
+    ? `Project · ${instance.project}`
+    : 'Project · default';
+
+  const getSelectedImageSource =
+    React.useCallback((): AdvancedInstanceRebuildSource => {
+      if (!selectedImage) {
+        throw new Error('Select an image before rebuilding this instance.');
+      }
+
+      if (selectedImage.local && selectedImage.fingerprint) {
+        return {
+          type: 'image',
+          fingerprint: selectedImage.fingerprint,
+        };
+      }
+
+      if (selectedImage.remote?.alias && selectedImage.remote?.server) {
+        return {
+          type: 'image',
+          alias: selectedImage.remote.alias,
+          server: selectedImage.remote.server,
+          mode: 'pull',
+          protocol: selectedImage.remote.protocol,
+        };
+      }
+
+      throw new Error('The selected image is missing the data needed for rebuild.');
+    }, [selectedImage]);
+
+  const getRebuildSource = React.useCallback((): AdvancedInstanceRebuildSource => {
+    if (yamlSourceOverride) {
+      return yamlSourceOverride;
+    }
+
+    if (rebuildMode === 'empty') {
+      return { type: 'none' };
+    }
+
+    return getSelectedImageSource();
+  }, [getSelectedImageSource, rebuildMode, yamlSourceOverride]);
+
+  const updateYamlSourceOverride = React.useCallback(
+    (nextSource: AdvancedInstanceRebuildSource | null) => {
+      setYamlSourceOverride(nextSource);
+
+      if (!nextSource) {
+        setSourceYamlError(null);
+        return;
+      }
+
+      setSourceYamlContent(
+        toYaml(nextSource as unknown as Record<string, unknown>),
+      );
+      setSourceYamlError(null);
+    },
+    [],
+  );
+
+  const syncSelectedImageFromSource = React.useCallback(
+    (nextSource: AdvancedInstanceRebuildSource) => {
+      if (nextSource.type !== 'image') {
+        setSelectedImage(null);
+        return;
+      }
+
+      if (nextSource.fingerprint) {
+        setSelectedImage((current) =>
+          current?.fingerprint === nextSource.fingerprint
+            ? current
+            : null,
+        );
+        return;
+      }
+
+      if (nextSource.alias && nextSource.server) {
+        setSelectedImage((current) =>
+          current?.remote?.alias === nextSource.alias &&
+          current?.remote?.server === nextSource.server
+            ? current
+            : null,
+        );
+        return;
+      }
+
+      setSelectedImage(null);
+    },
+    [],
+  );
+
+  const handleSourceYamlChange = React.useCallback(
+    (value: string | undefined) => {
+      const nextValue = value ?? '';
+      setSourceYamlContent(nextValue);
+
+      try {
+        const parsed = fromYaml(nextValue);
+        const type = parsed.type;
+
+        if (type !== 'image' && type !== 'none') {
+          throw new Error('Source YAML must include type: image or type: none.');
+        }
+
+        if (type === 'none') {
+          const nextSource: AdvancedInstanceRebuildSource = { type: 'none' };
+          setRebuildMode('empty');
+          updateYamlSourceOverride(nextSource);
+          syncSelectedImageFromSource(nextSource);
+          return;
+        }
+
+        const fingerprint =
+          typeof parsed.fingerprint === 'string' && parsed.fingerprint.trim()
+            ? parsed.fingerprint.trim()
+            : undefined;
+        const alias =
+          typeof parsed.alias === 'string' && parsed.alias.trim()
+            ? parsed.alias.trim()
+            : undefined;
+        const server =
+          typeof parsed.server === 'string' && parsed.server.trim()
+            ? parsed.server.trim()
+            : undefined;
+        const mode = parsed.mode;
+        const protocol = parsed.protocol;
+
+        if (!fingerprint && !(alias && server)) {
+          throw new Error(
+            'Image source YAML must include fingerprint or both alias and server.',
+          );
+        }
+
+        if (mode !== undefined && mode !== 'pull') {
+          throw new Error('Only mode: pull is supported for rebuild sources.');
+        }
+
+        if (
+          protocol !== undefined &&
+          protocol !== 'simplestreams' &&
+          protocol !== 'oci'
+        ) {
+          throw new Error(
+            'protocol must be either simplestreams or oci when provided.',
+          );
+        }
+
+        const nextSource: AdvancedInstanceRebuildSource = {
+          type: 'image',
+          ...(fingerprint ? { fingerprint } : {}),
+          ...(alias ? { alias } : {}),
+          ...(server ? { server } : {}),
+          ...(mode === 'pull' ? { mode } : {}),
+          ...(protocol ? { protocol } : {}),
+        };
+
+        setRebuildMode('image');
+        updateYamlSourceOverride(nextSource);
+        syncSelectedImageFromSource(nextSource);
+      } catch (error) {
+        setSourceYamlError(
+          error instanceof Error ? error.message : 'Invalid source YAML.',
+        );
+      }
+    },
+    [syncSelectedImageFromSource, updateYamlSourceOverride],
+  );
+
+  const handleToggleSourceYamlEditor = React.useCallback(() => {
+    if (!showSourceYamlEditor) {
+      try {
+        const currentSource = getRebuildSource();
+        setSourceYamlContent(
+          toYaml(currentSource as unknown as Record<string, unknown>),
+        );
+        setSourceYamlError(null);
+      } catch {
+        setSourceYamlContent(
+          toYaml({ type: rebuildMode } as unknown as Record<string, unknown>),
+        );
+      }
+    }
+
+    setShowSourceYamlEditor((current) => !current);
+  }, [getRebuildSource, rebuildMode, showSourceYamlEditor]);
+
+  const handleRebuildModeChange = React.useCallback(
+    (nextMode: RebuildMode) => {
+      setRebuildMode(nextMode);
+      setSourceYamlError(null);
+
+      if (nextMode === 'empty') {
+        const emptySource: AdvancedInstanceRebuildSource = { type: 'none' };
+        updateYamlSourceOverride(emptySource);
+        setSourceYamlContent(toYaml(emptySource as Record<string, unknown>));
+        return;
+      }
+
+      updateYamlSourceOverride(null);
+
+      try {
+        const imageSource = getSelectedImageSource();
+        setSourceYamlContent(toYaml(imageSource as Record<string, unknown>));
+      } catch {
+        setSourceYamlContent(toYaml({ type: 'image' } as Record<string, unknown>));
+      }
+    },
+    [getSelectedImageSource, updateYamlSourceOverride],
+  );
+
+  const handleDelete = async () => {
+    if (!canDelete) {
+      if (!canForceDelete || !forceDelete) {
+        return;
+      }
+    }
+
+    try {
+      setActionError(null);
+      setBusyAction('delete');
+      await deleteInstance(instance, canForceDelete && forceDelete);
+      setOpen(false);
+      React.startTransition(() => {
+        router.push('/instances');
+      });
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : 'Unable to delete instance.',
+      );
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const handleRebuild = async () => {
+    try {
+      setActionError(null);
+      setBusyAction('rebuild');
+      const source = getRebuildSource();
+      await rebuildInstance({ instance, source });
+      setOpen(false);
+      await onMutate();
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : 'Unable to rebuild instance.',
+      );
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const handleRepair = async () => {
+    try {
+      setActionError(null);
+      setBusyAction('repair');
+      await repairInstance({
+        instance,
+        action: 'rebuild-config-volume',
+      });
+      setOpen(false);
+      await onMutate();
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : 'Unable to repair instance.',
+      );
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const renderStatusIndicator = () => {
+    const status = instance.status?.toLowerCase();
+
+    if (status === 'running' || status === 'started') {
+      return (
+        <span className="absolute -right-1 -bottom-1 flex h-4 w-4">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+          <span className="relative inline-flex h-4 w-4 rounded-full bg-green-500" />
+        </span>
+      );
+    }
+
+    if (status === 'stopped') {
+      return (
+        <span className="absolute -right-1 -bottom-1 flex h-4 w-4">
+          <span className="relative inline-flex h-4 w-4 rounded-full bg-red-500" />
+        </span>
+      );
+    }
+
+    return (
+      <span className="absolute -right-1 -bottom-1 flex h-4 w-4">
+        <span className="relative inline-flex h-4 w-4 rounded-full bg-gray-400" />
+      </span>
+    );
+  };
+
+  const renderMenu = () => (
+    <div className="grid gap-3">
+      <ActionCard
+        icon={<RefreshCcwDotIcon className="size-4" />}
+        title="Rebuild instance"
+        description="Recreate the instance from a selected image or as empty."
+        onClick={() => setView('rebuild')}
+      />
+      {canRepair ? (
+        <ActionCard
+          icon={<WrenchIcon className="size-4" />}
+          title="Repair instance"
+          description="Run the supported low-level repair action for this instance."
+          onClick={() => setView('repair')}
+        />
+      ) : null}
+      <ActionCard
+        icon={<Trash2Icon className="size-4 text-destructive" />}
+        title="Delete instance"
+        description="Permanently remove this instance and all of its data."
+        onClick={() => setView('delete')}
+      />
+    </div>
+  );
+
+  const renderDeleteView = () => (
+    <div className="space-y-4">
+      <div className="rounded-md border border-destructive/20 bg-destructive/5 p-4 text-sm">
+        This action cannot be undone. This will permanently delete{' '}
+        <strong>{instance.name}</strong> and all of its data.
+      </div>
+
+      {isRunning ? (
+        <Alert>
+          <AlertTitle>Stop the instance first</AlertTitle>
+          <AlertDescription>
+            Running instances must be stopped before deletion. You can force a
+            stop first and then continue with deletion from here.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {isDeleteProtected ? (
+        <Alert>
+          <AlertTitle>Delete protection is enabled</AlertTitle>
+          <AlertDescription>
+            Disable <code>security.protection.delete</code> before deleting this
+            instance.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {!isRunning && !isDeleteProtected ? (
+        <p className="text-sm text-muted-foreground">
+          The delete request will be sent immediately and progress will be
+          tracked through the existing operation events.
+        </p>
+      ) : null}
+
+      {canForceDelete ? (
+        <label className="flex items-start gap-3 rounded-md border bg-muted/20 p-3 text-sm">
+          <Checkbox
+            checked={forceDelete}
+            onCheckedChange={(checked) => setForceDelete(checked === true)}
+            disabled={isBusy}
+            aria-label="Force stop before deleting"
+          />
+          <span className="space-y-1">
+            <span className="block font-medium">Force stop before delete</span>
+            <span className="block text-muted-foreground">
+              Stop the running instance with force, wait for it to stop, then
+              delete it.
+            </span>
+          </span>
+        </label>
+      ) : null}
+
+      <DialogFooter>
+        <Button variant="outline" onClick={() => setView('menu')} disabled={isBusy}>
+          Back
+        </Button>
+        <Button
+          variant="destructive"
+          loading={busyAction === 'delete'}
+          disabled={(!canDelete && !(canForceDelete && forceDelete)) || isBusy}
+          onClick={() => void handleDelete()}
+        >
+          {canForceDelete && forceDelete ? 'Force stop and delete' : 'Delete instance'}
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+
+  const renderRebuildView = () => (
+    <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)_auto] gap-4 overflow-hidden">
+      {!showSourceYamlEditor ? (
+        <div className="grid gap-2">
+          <p className="text-sm font-medium">Rebuild source</p>
+          <Select
+            value={rebuildMode}
+            onValueChange={(value) =>
+              handleRebuildModeChange(value as RebuildMode)
+            }
+            disabled={isBusy}
+          >
+            <SelectTrigger className="w-full sm:w-64">
+              <SelectValue placeholder="Select rebuild source" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="image">Image</SelectItem>
+              <SelectItem value="empty">Empty rebuild</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      ) : null}
+
+      {rebuildMode === 'image' ? (
+        <div className="min-h-0 overflow-hidden">
+          {showSourceYamlEditor ? (
+            <div className="h-[24rem] min-h-[24rem] overflow-hidden">
+              <SettingsYamlEditor
+                value={sourceYamlContent}
+                error={sourceYamlError}
+                onChange={handleSourceYamlChange}
+              />
+            </div>
+          ) : (
+            <ImageSelector
+              selectedImage={selectedImage}
+              onSelect={(image) => {
+                setSelectedImage(image);
+                updateYamlSourceOverride(null);
+                setSourceYamlError(null);
+              }}
+              instanceType={
+                instance.type === 'virtual-machine'
+                  ? 'virtual-machine'
+                  : 'container'
+              }
+              project={instance.project ?? null}
+              projectLabel={projectLabel}
+              emptyDescription="Select the image to use for the rebuild."
+              defaultSelection={{
+                fingerprint:
+                  instance.expanded_config?.['volatile.base_image'] ??
+                  instance.config?.['volatile.base_image'] ??
+                  null,
+                alias: instance.config?.['image.alias'] ?? null,
+                description: instance.config?.['image.description'] ?? null,
+              }}
+            />
+          )}
+        </div>
+      ) : (
+        <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+          An empty rebuild recreates the instance without selecting an image
+          source.
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3 border-t pt-4">
+        <div>
+          {rebuildMode === 'image' ? (
+            <Button
+              variant="outline"
+              onClick={handleToggleSourceYamlEditor}
+              disabled={isBusy}
+            >
+              {showSourceYamlEditor ? (
+                <PackageIcon className="mr-2 h-4 w-4" />
+              ) : (
+                <CodeXmlIcon className="mr-2 h-4 w-4" />
+              )}
+              {showSourceYamlEditor ? 'Back to image list' : 'Edit YAML'}
+            </Button>
+          ) : null}
+        </div>
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setView('menu')}
+            disabled={isBusy}
+          >
+            Back
+          </Button>
+          <Button
+            loading={busyAction === 'rebuild'}
+            disabled={Boolean(sourceYamlError)}
+            onClick={() => void handleRebuild()}
+          >
+            Rebuild instance
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderRepairView = () => (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-muted/30 p-4 text-sm">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">Supported action</span>
+          <Badge variant="outline">rebuild-config-volume</Badge>
+        </div>
+        <p className="mt-2 text-muted-foreground">
+          This triggers the currently supported low-level repair action exposed
+          by Incus for this instance.
+        </p>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={() => setView('menu')} disabled={isBusy}>
+          Back
+        </Button>
+        <Button loading={busyAction === 'repair'} onClick={() => void handleRepair()}>
+          Run repair
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={disabled}
+          className="group relative h-16 w-16 rounded-lg border bg-muted p-0 hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label="Open instance actions"
+        >
+          <OSLogo brand={getBaseImage(instance)} className="size-8" />
+          <span className="absolute inset-0 rounded-lg bg-background/75 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+          <Settings2Icon className="absolute size-5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100" />
+          {renderStatusIndicator()}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="flex max-h-[85vh] flex-col overflow-hidden sm:max-w-4xl">
+        <DialogHeader className="shrink-0">
+          <div className="flex items-center gap-2">
+            {view !== 'menu' ? (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => setView('menu')}
+                disabled={isBusy}
+                aria-label="Back to actions menu"
+              >
+                <ArrowLeftIcon className="size-4" />
+              </Button>
+            ) : null}
+            <DialogTitle>{getDialogTitle(view, instance.name)}</DialogTitle>
+          </div>
+          <DialogDescription>
+            {getDialogDescription(view, instance.name)}
+          </DialogDescription>
+        </DialogHeader>
+
+        {actionError ? (
+          <Alert variant="destructive">
+            <AlertTitle>Action failed</AlertTitle>
+            <AlertDescription>{actionError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {view === 'menu' ? renderMenu() : null}
+        {view === 'delete' ? renderDeleteView() : null}
+        {view === 'rebuild' ? renderRebuildView() : null}
+        {view === 'repair' && canRepair ? renderRepairView() : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ActionCard({
+  icon,
+  title,
+  description,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-start gap-3 rounded-lg border p-4 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      onClick={onClick}
+    >
+      <span className="mt-0.5 rounded-md border bg-background p-2">{icon}</span>
+      <span className="space-y-1">
+        <span className="block font-medium">{title}</span>
+        <span className="block text-sm text-muted-foreground">
+          {description}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function getDialogTitle(view: ActionView, instanceName: string) {
+  switch (view) {
+    case 'delete':
+      return `Delete ${instanceName}`;
+    case 'rebuild':
+      return `Rebuild ${instanceName}`;
+    case 'repair':
+      return `Repair ${instanceName}`;
+    default:
+      return `${instanceName} actions`;
+  }
+}
+
+function getDialogDescription(view: ActionView, instanceName: string) {
+  switch (view) {
+    case 'delete':
+      return 'Confirm the destructive delete action for this instance.';
+    case 'rebuild':
+      return 'Choose how to rebuild this instance.';
+    case 'repair':
+      return 'Run the supported repair action for this instance.';
+    default:
+      return `Manage destructive and recovery actions for ${instanceName}.`;
+  }
+}

--- a/app/(main)/instance/_components/management/clone.tsx
+++ b/app/(main)/instance/_components/management/clone.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import * as React from 'react';
+import ProjectsContext from '@/app/(main)/_context/projects';
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxItem,
+  ComboboxTrigger,
+} from '@/components/ui/combobox';
+import { useStoragePools } from '@/app/(main)/_hooks/storagePools';
+import type { Instance } from '@/app/(main)/instances/_lib/instances.d';
+import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
+import { Checkbox } from 'ui-web/components/checkbox';
+import { Input } from 'ui-web/components/input';
+import { cloneInstance } from '../../_lib/instance';
+import { ManagementFooter } from './footer';
+
+export default function Clone({
+  instance,
+  onBack,
+  onDone,
+}: {
+  instance: Instance;
+  onBack: () => void;
+  onDone: () => Promise<void>;
+}) {
+  const { projects } = React.useContext(ProjectsContext);
+  const { data: storagePools } = useStoragePools();
+  const rootDiskPoolName =
+    instance.expanded_devices?.root?.pool ?? instance.devices?.root?.pool ?? null;
+  const [name, setName] = React.useState(`${instance.name}-copy`);
+  const [targetProject, setTargetProject] = React.useState(
+    instance.project ?? 'default',
+  );
+  const [rootStoragePool, setRootStoragePool] = React.useState(
+    rootDiskPoolName ?? '',
+  );
+  const [allowInconsistent, setAllowInconsistent] = React.useState(false);
+  const [instanceOnly, setInstanceOnly] = React.useState(false);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    setName(`${instance.name}-copy`);
+    setTargetProject(instance.project ?? 'default');
+    setRootStoragePool(rootDiskPoolName ?? storagePools?.[0]?.name ?? '');
+    setAllowInconsistent(false);
+    setInstanceOnly(false);
+    setError(null);
+  }, [instance.name, instance.project, rootDiskPoolName, storagePools]);
+
+  const availableTargetProjects = React.useMemo(() => {
+    const names = new Set(projects.map((project) => project.name));
+    names.add(targetProject || instance.project || 'default');
+    return Array.from(names).sort((left, right) => left.localeCompare(right));
+  }, [instance.project, projects, targetProject]);
+
+  const availableRootStoragePools = React.useMemo(() => {
+    const names = new Set((storagePools ?? []).map((pool) => pool.name));
+    if (rootDiskPoolName) {
+      names.add(rootDiskPoolName);
+    }
+    if (rootStoragePool) {
+      names.add(rootStoragePool);
+    }
+    return Array.from(names).sort((left, right) => left.localeCompare(right));
+  }, [rootDiskPoolName, rootStoragePool, storagePools]);
+
+  const handleClone = async () => {
+    try {
+      setError(null);
+      setIsSaving(true);
+      await cloneInstance({
+        instance,
+        name,
+        targetProject,
+        rootStoragePool,
+        allowInconsistent,
+        instanceOnly,
+      });
+      await onDone();
+    } catch (cloneError) {
+      setError(
+        cloneError instanceof Error ? cloneError.message : 'Unable to clone instance.',
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Action failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2 sm:col-span-2">
+          <p className="text-sm font-medium">Name</p>
+          <Input
+            value={name}
+            onChange={(event) => setName(event.currentTarget.value)}
+            placeholder={`${instance.name}-copy`}
+            disabled={isSaving}
+          />
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Root storage pool</p>
+          <Combobox
+            value={rootStoragePool}
+            onValueChange={setRootStoragePool}
+            disabled={isSaving}
+          >
+            <ComboboxTrigger placeholder="Select storage pool" />
+            <ComboboxContent
+              searchPlaceholder="Search storage pools..."
+              emptyLabel="No storage pools found."
+            >
+              {availableRootStoragePools.map((poolName) => (
+                <ComboboxItem
+                  key={poolName}
+                  value={poolName}
+                  description={
+                    storagePools?.find((pool) => pool.name === poolName)?.driver
+                  }
+                >
+                  {poolName}
+                </ComboboxItem>
+              ))}
+            </ComboboxContent>
+          </Combobox>
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Target project</p>
+          <Combobox
+            value={targetProject}
+            onValueChange={setTargetProject}
+            disabled={isSaving}
+          >
+            <ComboboxTrigger placeholder="Select target project" />
+            <ComboboxContent
+              searchPlaceholder="Search projects..."
+              emptyLabel="No projects found."
+            >
+              {availableTargetProjects.map((projectName) => (
+                <ComboboxItem
+                  key={projectName}
+                  value={projectName}
+                  description={
+                    projects.find((project) => project.name === projectName)
+                      ?.description
+                  }
+                >
+                  {projectName}
+                </ComboboxItem>
+              ))}
+            </ComboboxContent>
+          </Combobox>
+        </div>
+      </div>
+
+      <label className="flex items-start gap-3 rounded-md border bg-muted/20 p-3 text-sm">
+        <Checkbox
+          checked={allowInconsistent}
+          onCheckedChange={(checked) => setAllowInconsistent(checked === true)}
+          disabled={isSaving}
+          aria-label="Ignore copy errors for volatile files"
+        />
+        <span className="space-y-1">
+          <span className="block font-medium">
+            Ignore copy errors for volatile files
+          </span>
+          <span className="block text-muted-foreground">
+            Continue the copy even if volatile files cannot be copied consistently.
+          </span>
+        </span>
+      </label>
+
+      <label className="flex items-start gap-3 rounded-md border bg-muted/20 p-3 text-sm">
+        <Checkbox
+          checked={instanceOnly}
+          onCheckedChange={(checked) => setInstanceOnly(checked === true)}
+          disabled={isSaving}
+          aria-label="Copy without instance snapshots"
+        />
+        <span className="space-y-1">
+          <span className="block font-medium">Copy without instance snapshots</span>
+          <span className="block text-muted-foreground">
+            Skip source snapshots and clone only the main instance.
+          </span>
+        </span>
+      </label>
+
+      <ManagementFooter
+        onBack={onBack}
+        backDisabled={isSaving}
+        primaryLabel="Clone Instance"
+        onPrimary={handleClone}
+        primaryDisabled={
+          !name.trim() || !targetProject.trim() || !rootStoragePool.trim()
+        }
+        primaryLoading={isSaving}
+      />
+    </div>
+  );
+}

--- a/app/(main)/instance/_components/management/configuration.tsx
+++ b/app/(main)/instance/_components/management/configuration.tsx
@@ -2,23 +2,27 @@
 
 import * as React from 'react';
 import stableStringify from 'fast-json-stable-stringify';
+import { CodeXmlIcon } from 'lucide-react';
 
-import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
 import { Button } from 'ui-web/components/button';
-import { cn } from 'ui-web/lib/utils';
 
-import GeneralConfiguration from '../../_components/general-configuration';
-import { useInstanceContext } from '../_context/instance';
-import { updateInstanceSettings } from '../_lib/instance';
-import { SettingsPageActions } from '../_components/settings-page-actions';
-import { SettingsYamlEditor } from '../_components/settings-yaml-editor';
-import {
-  parseConfigYaml,
-  serializeConfigYaml,
-} from '../_lib/settings-yaml';
+import GeneralConfiguration from '@/app/(main)/_components/general-configuration';
+import type { Instance } from '@/app/(main)/instances/_lib/instances.d';
+import { updateInstanceSettings } from '../../_lib/instance';
+import { SettingsYamlEditor } from '../settings-yaml-editor';
+import { parseConfigYaml, serializeConfigYaml } from '../../_lib/settings-yaml';
+import { ManagementFooter } from './footer';
+import { ManagementShell } from './shell';
 
-export default function ConfigurationPage() {
-  const { instance, mutate } = useInstanceContext();
+export default function Configuration({
+  instance,
+  onMutate,
+  onBack,
+}: {
+  instance: Instance;
+  onMutate: () => Promise<void>;
+  onBack?: () => void;
+}) {
   const [draftConfig, setDraftConfig] = React.useState<Record<string, string>>({});
   const [isSaving, setIsSaving] = React.useState(false);
   const [saveError, setSaveError] = React.useState<string | null>(null);
@@ -36,12 +40,12 @@ export default function ConfigurationPage() {
   }, []);
 
   const currentConfig = React.useMemo(
-    () => instance?.config ?? {},
-    [instance?.config],
+    () => instance.config ?? {},
+    [instance.config],
   );
   const expandedConfig = React.useMemo(
-    () => instance?.expanded_config ?? {},
-    [instance?.expanded_config],
+    () => instance.expanded_config ?? {},
+    [instance.expanded_config],
   );
   const serializedCurrentConfig = React.useMemo(
     () => stableStringify(currentConfig),
@@ -54,10 +58,6 @@ export default function ConfigurationPage() {
   const isDirty = serializedDraftConfig !== serializedCurrentConfig;
 
   React.useEffect(() => {
-    if (!instance) {
-      return;
-    }
-
     const instanceChanged = lastInstanceNameRef.current !== instance.name;
     const serverChanged = lastSyncedSnapshotRef.current !== serializedCurrentConfig;
 
@@ -69,11 +69,7 @@ export default function ConfigurationPage() {
     setSaveError(null);
     lastSyncedSnapshotRef.current = serializedCurrentConfig;
     lastInstanceNameRef.current = instance.name;
-  }, [currentConfig, instance, isDirty, serializedCurrentConfig]);
-
-  if (!instance) {
-    return null;
-  }
+  }, [currentConfig, instance.name, isDirty, serializedCurrentConfig]);
 
   const instanceType =
     instance.type === 'virtual-machine' ? 'virtual-machine' : 'container';
@@ -112,7 +108,7 @@ export default function ConfigurationPage() {
   };
 
   const handleSave = async () => {
-    if (!instance || !isDirty || isSaving) {
+    if (!isDirty || isSaving) {
       return;
     }
 
@@ -128,7 +124,7 @@ export default function ConfigurationPage() {
         nextConfig: draftConfig,
         signal: abortController.signal,
       });
-      await mutate();
+      await onMutate();
 
       lastSyncedSnapshotRef.current = stableStringify(draftConfig);
     } catch (error) {
@@ -136,11 +132,11 @@ export default function ConfigurationPage() {
         return;
       }
 
-      const message =
+      setSaveError(
         error instanceof Error
           ? error.message
-          : 'Unable to update instance configuration.';
-      setSaveError(message);
+          : 'Unable to update instance configuration.',
+      );
     } finally {
       saveAbortControllerRef.current = null;
       setIsSaving(false);
@@ -148,56 +144,51 @@ export default function ConfigurationPage() {
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4">
-      <div
-        className={cn(
-          'bg-card text-card-foreground flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border shadow-sm',
-        )}
-      >
-        {saveError ? (
-          <Alert variant="destructive" className="mx-6 mt-6">
-            <AlertTitle>Save failed</AlertTitle>
-            <AlertDescription>{saveError}</AlertDescription>
-          </Alert>
-        ) : null}
-        <div className="min-h-0 flex-1">
-          {showYamlEditor ? (
-            <SettingsYamlEditor
-              value={yamlContent}
-              error={yamlError}
-              onChange={handleYamlChange}
-              description="Edit the raw instance configuration YAML. Changes stay synced with the structured editor."
-            />
-          ) : (
-            <GeneralConfiguration
-              config={draftConfig}
-              expandedConfig={expandedConfig}
-              onConfigChange={setDraftConfig}
-              instanceType={instanceType}
-              configTarget="instance"
-              className="rounded-none border-0"
-            />
-          )}
-        </div>
-        <SettingsPageActions
-          isDirty={isDirty}
-          isSaving={isSaving}
-          onCancel={handleCancel}
-          onSave={handleSave}
-          className="px-6 py-4"
-          saveDisabled={Boolean(yamlError)}
-          extraActions={
+    <ManagementShell
+      error={saveError}
+      footer={
+        <ManagementFooter
+          left={
             <Button
               type="button"
               variant="outline"
               disabled={isSaving}
               onClick={toggleYamlEditor}
             >
-{showYamlEditor ? 'Back to form' : 'Edit YAML'}
+              <CodeXmlIcon className="mr-2 size-4" />
+              {showYamlEditor ? 'Back to Wizard' : 'Edit YAML'}
             </Button>
           }
+          backLabel={onBack ? 'Back' : 'Reset'}
+          onBack={onBack ?? handleCancel}
+          backDisabled={isSaving}
+          primaryLabel="Save Changes"
+          onPrimary={handleSave}
+          primaryDisabled={!isDirty || isSaving || Boolean(yamlError)}
+          primaryLoading={isSaving}
         />
-      </div>
-    </div>
+      }
+    >
+      {showYamlEditor ? (
+        <SettingsYamlEditor
+          value={yamlContent}
+          error={yamlError}
+          onChange={handleYamlChange}
+          description="Edit the raw instance configuration YAML. Changes stay synced with the structured editor."
+          className="h-full"
+        />
+      ) : (
+        <div className="h-full overflow-y-auto">
+          <GeneralConfiguration
+            config={draftConfig}
+            expandedConfig={expandedConfig}
+            onConfigChange={setDraftConfig}
+            instanceType={instanceType}
+            configTarget="instance"
+            className="rounded-xl border"
+          />
+        </div>
+      )}
+    </ManagementShell>
   );
 }

--- a/app/(main)/instance/_components/management/delete.tsx
+++ b/app/(main)/instance/_components/management/delete.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import * as React from 'react';
+
+import type { Instance } from '@/app/(main)/instances/_lib/instances.d';
+import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
+import { Checkbox } from 'ui-web/components/checkbox';
+import {
+  canDeleteInstance,
+  deleteInstance,
+  isInstanceDeleteProtected,
+  isInstanceRunning,
+} from '../../_lib/instance';
+import { ManagementFooter } from './footer';
+
+export default function Delete({
+  instance,
+  onBack,
+  onDone,
+}: {
+  instance: Instance;
+  onBack: () => void;
+  onDone: () => Promise<void>;
+}) {
+  const [forceDelete, setForceDelete] = React.useState(false);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const isRunning = isInstanceRunning(instance);
+  const isDeleteProtected = isInstanceDeleteProtected(instance);
+  const canDelete = canDeleteInstance(instance);
+  const canForceDelete = isRunning && !isDeleteProtected;
+
+  React.useEffect(() => {
+    setForceDelete(false);
+    setError(null);
+  }, [instance.name]);
+
+  const handleDelete = async () => {
+    if (!canDelete && !(canForceDelete && forceDelete)) {
+      return;
+    }
+
+    try {
+      setError(null);
+      setIsSaving(true);
+      await deleteInstance(instance, canForceDelete && forceDelete);
+      await onDone();
+    } catch (deleteError) {
+      setError(
+        deleteError instanceof Error
+          ? deleteError.message
+          : 'Unable to delete instance.',
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Action failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="rounded-md border border-destructive/20 bg-destructive/5 p-4 text-sm">
+        This action cannot be undone. This will permanently delete{' '}
+        <strong>{instance.name}</strong> and all of its data.
+      </div>
+
+      {isRunning ? (
+        <Alert>
+          <AlertTitle>Stop the instance first</AlertTitle>
+          <AlertDescription>
+            Running instances must be stopped before deletion. You can force a stop
+            first and then continue with deletion from here.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {isDeleteProtected ? (
+        <Alert>
+          <AlertTitle>Delete protection is enabled</AlertTitle>
+          <AlertDescription>
+            Disable <code>security.protection.delete</code> before deleting this
+            instance.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {!isRunning && !isDeleteProtected ? (
+        <p className="text-sm text-muted-foreground">
+          The delete request will be sent immediately and progress will be tracked
+          through the existing operation events.
+        </p>
+      ) : null}
+
+      {canForceDelete ? (
+        <label className="flex items-start gap-3 rounded-md border bg-muted/20 p-3 text-sm">
+          <Checkbox
+            checked={forceDelete}
+            onCheckedChange={(checked) => setForceDelete(checked === true)}
+            disabled={isSaving}
+            aria-label="Force stop before deleting"
+          />
+          <span className="space-y-1">
+            <span className="block font-medium">Force stop before delete</span>
+            <span className="block text-muted-foreground">
+              Stop the running instance with force, wait for it to stop, then delete it.
+            </span>
+          </span>
+        </label>
+      ) : null}
+
+      <ManagementFooter
+        onBack={onBack}
+        backDisabled={isSaving}
+        primaryLabel={
+          canForceDelete && forceDelete ? 'Force stop and delete' : 'Delete instance'
+        }
+        onPrimary={handleDelete}
+        primaryDisabled={(!canDelete && !(canForceDelete && forceDelete)) || isSaving}
+        primaryLoading={isSaving}
+        primaryVariant="destructive"
+      />
+    </div>
+  );
+}

--- a/app/(main)/instance/_components/management/devices.tsx
+++ b/app/(main)/instance/_components/management/devices.tsx
@@ -2,24 +2,27 @@
 
 import * as React from 'react';
 import stableStringify from 'fast-json-stable-stringify';
+import { CodeXmlIcon } from 'lucide-react';
 
-import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
 import { Button } from 'ui-web/components/button';
-import { cn } from 'ui-web/lib/utils';
 
-import { useInstanceContext } from '../_context/instance';
-import { updateInstanceSettings } from '../_lib/instance';
-import { SettingsPageActions } from '../_components/settings-page-actions';
-import { SettingsYamlEditor } from '../_components/settings-yaml-editor';
-import {
-  parseDevicesYaml,
-  serializeDevicesYaml,
-} from '../_lib/settings-yaml';
-import InstanceDevices from '../../instances/_components/devices';
-import type { Device } from '../../instances/_lib/instances.d';
+import type { Device, Instance } from '@/app/(main)/instances/_lib/instances.d';
+import InstanceDevices from '@/app/(main)/instances/_components/devices';
+import { updateInstanceSettings } from '../../_lib/instance';
+import { SettingsYamlEditor } from '../settings-yaml-editor';
+import { parseDevicesYaml, serializeDevicesYaml } from '../../_lib/settings-yaml';
+import { ManagementFooter } from './footer';
+import { ManagementShell } from './shell';
 
-export default function DevicesPage() {
-  const { instance, mutate } = useInstanceContext();
+export default function Devices({
+  instance,
+  onMutate,
+  onBack,
+}: {
+  instance: Instance;
+  onMutate: () => Promise<void>;
+  onBack?: () => void;
+}) {
   const [draftDevices, setDraftDevices] = React.useState<Record<string, Device>>({});
   const [isSaving, setIsSaving] = React.useState(false);
   const [saveError, setSaveError] = React.useState<string | null>(null);
@@ -37,8 +40,8 @@ export default function DevicesPage() {
   }, []);
 
   const currentDevices = React.useMemo(
-    () => ((instance?.devices as Record<string, Device> | undefined) ?? {}),
-    [instance?.devices],
+    () => (instance.devices as Record<string, Device> | undefined) ?? {},
+    [instance.devices],
   );
   const serializedCurrentDevices = React.useMemo(
     () => stableStringify(currentDevices),
@@ -51,10 +54,6 @@ export default function DevicesPage() {
   const isDirty = serializedDraftDevices !== serializedCurrentDevices;
 
   React.useEffect(() => {
-    if (!instance) {
-      return;
-    }
-
     const instanceChanged = lastInstanceNameRef.current !== instance.name;
     const serverChanged = lastSyncedSnapshotRef.current !== serializedCurrentDevices;
 
@@ -66,11 +65,7 @@ export default function DevicesPage() {
     setSaveError(null);
     lastSyncedSnapshotRef.current = serializedCurrentDevices;
     lastInstanceNameRef.current = instance.name;
-  }, [currentDevices, instance, isDirty, serializedCurrentDevices]);
-
-  if (!instance) {
-    return null;
-  }
+  }, [currentDevices, instance.name, isDirty, serializedCurrentDevices]);
 
   const instanceType =
     instance.type === 'virtual-machine' ? 'virtual-machine' : 'container';
@@ -109,7 +104,7 @@ export default function DevicesPage() {
   };
 
   const handleSave = async () => {
-    if (!instance || !isDirty || isSaving) {
+    if (!isDirty || isSaving) {
       return;
     }
 
@@ -125,7 +120,7 @@ export default function DevicesPage() {
         nextDevices: draftDevices,
         signal: abortController.signal,
       });
-      await mutate();
+      await onMutate();
 
       lastSyncedSnapshotRef.current = stableStringify(draftDevices);
     } catch (error) {
@@ -133,11 +128,9 @@ export default function DevicesPage() {
         return;
       }
 
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Unable to update instance devices.';
-      setSaveError(message);
+      setSaveError(
+        error instanceof Error ? error.message : 'Unable to update instance devices.',
+      );
     } finally {
       saveAbortControllerRef.current = null;
       setIsSaving(false);
@@ -145,53 +138,50 @@ export default function DevicesPage() {
   };
 
   return (
-    <div
-      className={cn(
-        'bg-card text-card-foreground flex h-full min-h-[32rem] flex-col overflow-hidden rounded-xl border shadow-sm',
-      )}
+    <ManagementShell
+      error={saveError}
+      footer={
+        <ManagementFooter
+          left={
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isSaving}
+              onClick={toggleYamlEditor}
+            >
+              <CodeXmlIcon className="mr-2 size-4" />
+              {showYamlEditor ? 'Back to Wizard' : 'Edit YAML'}
+            </Button>
+          }
+          backLabel={onBack ? 'Back' : 'Reset'}
+          onBack={onBack ?? handleCancel}
+          backDisabled={isSaving}
+          primaryLabel="Save Changes"
+          onPrimary={handleSave}
+          primaryDisabled={!isDirty || isSaving || Boolean(yamlError)}
+          primaryLoading={isSaving}
+        />
+      }
     >
-      {saveError ? (
-        <Alert variant="destructive" className="mx-6 mt-6">
-          <AlertTitle>Save failed</AlertTitle>
-          <AlertDescription>{saveError}</AlertDescription>
-        </Alert>
-      ) : null}
-      <div className="min-h-0 flex-1">
-        {showYamlEditor ? (
-          <SettingsYamlEditor
-            value={yamlContent}
-            error={yamlError}
-            onChange={handleYamlChange}
-            description="Edit the raw instance devices YAML. Changes stay synced with the structured editor."
-          />
-        ) : (
+      {showYamlEditor ? (
+        <SettingsYamlEditor
+          value={yamlContent}
+          error={yamlError}
+          onChange={handleYamlChange}
+          description="Edit the raw instance devices YAML. Changes stay synced with the structured editor."
+          className="h-full"
+        />
+      ) : (
+        <div className="h-full overflow-y-auto">
           <InstanceDevices
             profiles={instance.profiles ?? ['default']}
             devices={draftDevices}
             onDevicesChange={setDraftDevices}
             instanceType={instanceType}
-            className="rounded-none border-0"
+            className="rounded-xl border"
           />
-        )}
-      </div>
-      <SettingsPageActions
-        isDirty={isDirty}
-        isSaving={isSaving}
-        onCancel={handleCancel}
-        onSave={handleSave}
-        className="px-6 py-4"
-        saveDisabled={Boolean(yamlError)}
-        extraActions={
-          <Button
-            type="button"
-            variant="outline"
-            disabled={isSaving}
-            onClick={toggleYamlEditor}
-          >
-{showYamlEditor ? 'Back to form' : 'Edit YAML'}
-          </Button>
-        }
-      />
-    </div>
+        </div>
+      )}
+    </ManagementShell>
   );
 }

--- a/app/(main)/instance/_components/management/footer.tsx
+++ b/app/(main)/instance/_components/management/footer.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import * as React from 'react';
+
+import { Button } from 'ui-web/components/button';
+import { DialogFooter } from 'ui-web/components/dialog';
+
+export function ManagementFooter({
+  left,
+  backLabel = 'Back',
+  onBack,
+  backDisabled = false,
+  primaryLabel,
+  onPrimary,
+  primaryDisabled = false,
+  primaryLoading = false,
+  primaryVariant,
+}: {
+  left?: React.ReactNode;
+  backLabel?: string;
+  onBack: () => void;
+  backDisabled?: boolean;
+  primaryLabel: string;
+  onPrimary: () => void | Promise<void>;
+  primaryDisabled?: boolean;
+  primaryLoading?: boolean;
+  primaryVariant?: 'default' | 'destructive';
+}) {
+  return (
+    <DialogFooter className="mt-4 flex w-full flex-row items-center justify-between gap-3 border-t pt-4 sm:flex-row sm:justify-between">
+      <div className="flex items-center">{left}</div>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={onBack} disabled={backDisabled}>
+          {backLabel}
+        </Button>
+        <Button
+          variant={primaryVariant}
+          loading={primaryLoading}
+          disabled={primaryDisabled}
+          onClick={() => void onPrimary()}
+        >
+          {primaryLabel}
+        </Button>
+      </div>
+    </DialogFooter>
+  );
+}

--- a/app/(main)/instance/_components/management/profiles.tsx
+++ b/app/(main)/instance/_components/management/profiles.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import * as React from 'react';
+import stableStringify from 'fast-json-stable-stringify';
+
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxItem,
+  ComboboxTrigger,
+} from '@/components/ui/combobox';
+import { useProfiles } from '@/app/(main)/_hooks/profiles';
+import type { Instance } from '@/app/(main)/instances/_lib/instances.d';
+import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
+import { updateInstanceSettings } from '../../_lib/instance';
+import { ManagementFooter } from './footer';
+
+export default function Profiles({
+  instance,
+  onMutate,
+  onBack,
+}: {
+  instance: Instance;
+  onMutate: () => Promise<void>;
+  onBack?: () => void;
+}) {
+  const currentProfiles = React.useMemo(
+    () => instance.profiles ?? ['default'],
+    [instance.profiles],
+  );
+  const { data: profiles, isLoading, isValidating } = useProfiles();
+  const [draftProfiles, setDraftProfiles] = React.useState<string[]>(currentProfiles);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
+  const lastSyncedSnapshotRef = React.useRef<string>('');
+  const lastInstanceNameRef = React.useRef<string | null>(null);
+  const saveAbortControllerRef = React.useRef<AbortController | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      saveAbortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const serializedCurrentProfiles = React.useMemo(
+    () => stableStringify(currentProfiles),
+    [currentProfiles],
+  );
+  const serializedDraftProfiles = React.useMemo(
+    () => stableStringify(draftProfiles),
+    [draftProfiles],
+  );
+  const isDirty = serializedDraftProfiles !== serializedCurrentProfiles;
+
+  React.useEffect(() => {
+    const instanceChanged = lastInstanceNameRef.current !== instance.name;
+    const serverChanged = lastSyncedSnapshotRef.current !== serializedCurrentProfiles;
+
+    if (!instanceChanged && (isDirty || !serverChanged)) {
+      return;
+    }
+
+    setDraftProfiles(currentProfiles);
+    setSaveError(null);
+    lastSyncedSnapshotRef.current = serializedCurrentProfiles;
+    lastInstanceNameRef.current = instance.name;
+  }, [currentProfiles, instance.name, isDirty, serializedCurrentProfiles]);
+
+  const handleCancel = () => {
+    setDraftProfiles(currentProfiles);
+    setSaveError(null);
+    lastSyncedSnapshotRef.current = serializedCurrentProfiles;
+  };
+
+  const handleSave = async () => {
+    if (!isDirty || isSaving) {
+      return;
+    }
+
+    try {
+      setSaveError(null);
+      setIsSaving(true);
+      saveAbortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      saveAbortControllerRef.current = abortController;
+
+      await updateInstanceSettings({
+        instance,
+        nextProfiles: draftProfiles,
+        signal: abortController.signal,
+      });
+      await onMutate();
+
+      lastSyncedSnapshotRef.current = stableStringify(draftProfiles);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return;
+      }
+
+      setSaveError(
+        error instanceof Error ? error.message : 'Unable to update instance profiles.',
+      );
+    } finally {
+      saveAbortControllerRef.current = null;
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-col">
+      {saveError ? (
+        <Alert variant="destructive" className="mb-4">
+          <AlertTitle>Save failed</AlertTitle>
+          <AlertDescription>{saveError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Profiles</p>
+        <Combobox
+          multiple
+          values={draftProfiles}
+          onValuesChange={setDraftProfiles}
+          validating={isValidating}
+          disabled={isSaving}
+        >
+          <ComboboxTrigger placeholder="Profiles" id="instance-profiles" />
+          <ComboboxContent
+            searchPlaceholder="Search profiles..."
+            loading={isLoading}
+            emptyLabel="No profiles found."
+          >
+            {profiles?.map((profile) => (
+              <ComboboxItem
+                key={profile.name}
+                value={profile.name}
+                description={profile.description}
+              >
+                {profile.name}
+              </ComboboxItem>
+            ))}
+          </ComboboxContent>
+        </Combobox>
+      </div>
+
+      <ManagementFooter
+        backLabel={onBack ? 'Back' : 'Reset'}
+        onBack={onBack ?? handleCancel}
+        backDisabled={isSaving}
+        primaryLabel="Save Changes"
+        onPrimary={handleSave}
+        primaryDisabled={!isDirty || isSaving}
+        primaryLoading={isSaving}
+      />
+    </div>
+  );
+}

--- a/app/(main)/instance/_components/management/rebuild.tsx
+++ b/app/(main)/instance/_components/management/rebuild.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { z } from 'zod';
 
 import ImageSelector, {
   type SelectableImage,
@@ -23,6 +24,32 @@ import { SettingsYamlEditor } from '../settings-yaml-editor';
 import { ManagementFooter } from './footer';
 
 type RebuildMode = 'image' | 'empty';
+
+const rebuildSourceSchema = z
+  .object({
+    type: z.enum(['image', 'none']),
+    fingerprint: z.string().trim().min(1).optional(),
+    alias: z.string().trim().min(1).optional(),
+    server: z.string().trim().min(1).optional(),
+    mode: z.literal('pull').optional(),
+    protocol: z.enum(['simplestreams', 'oci']).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.type === 'none') {
+      return;
+    }
+
+    const hasFingerprint = Boolean(value.fingerprint);
+    const hasAliasAndServer = Boolean(value.alias && value.server);
+
+    if (!hasFingerprint && !hasAliasAndServer) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Image source YAML must include fingerprint or both alias and server.',
+      });
+    }
+  });
 
 export default function Rebuild({
   instance,
@@ -207,75 +234,25 @@ export default function Rebuild({
 
       try {
         const parsed = fromYaml(nextValue);
-        if (!parsed || typeof parsed !== 'object') {
-          throw new Error('Invalid source YAML.');
-        }
-        const parsedSource = parsed as Record<string, unknown>;
-        const type = parsedSource.type;
+        const nextSource = rebuildSourceSchema.parse(parsed) as AdvancedInstanceRebuildSource;
 
-        if (type !== 'image' && type !== 'none') {
-          throw new Error('Source YAML must include type: image or type: none.');
-        }
-
-        if (type === 'none') {
-          const nextSource: AdvancedInstanceRebuildSource = { type: 'none' };
+        if (nextSource.type === 'none') {
           setRebuildMode('empty');
           updateYamlSourceOverride(nextSource, true);
           syncSelectedImageFromSource(nextSource);
           return;
         }
 
-        const fingerprint =
-          typeof parsedSource.fingerprint === 'string' &&
-          parsedSource.fingerprint.trim()
-            ? parsedSource.fingerprint.trim()
-            : undefined;
-        const alias =
-          typeof parsedSource.alias === 'string' && parsedSource.alias.trim()
-            ? parsedSource.alias.trim()
-            : undefined;
-        const server =
-          typeof parsedSource.server === 'string' && parsedSource.server.trim()
-            ? parsedSource.server.trim()
-            : undefined;
-        const mode = parsedSource.mode;
-        const protocol = parsedSource.protocol;
-
-        if (!fingerprint && !(alias && server)) {
-          throw new Error(
-            'Image source YAML must include fingerprint or both alias and server.',
-          );
-        }
-
-        if (mode !== undefined && mode !== 'pull') {
-          throw new Error('Only mode: pull is supported for rebuild sources.');
-        }
-
-        if (
-          protocol !== undefined &&
-          protocol !== 'simplestreams' &&
-          protocol !== 'oci'
-        ) {
-          throw new Error(
-            'protocol must be either simplestreams or oci when provided.',
-          );
-        }
-
-        const nextSource: AdvancedInstanceRebuildSource = {
-          type: 'image',
-          ...(fingerprint ? { fingerprint } : {}),
-          ...(alias ? { alias } : {}),
-          ...(server ? { server } : {}),
-          ...(mode === 'pull' ? { mode } : {}),
-          ...(protocol ? { protocol } : {}),
-        };
-
         setRebuildMode('image');
         updateYamlSourceOverride(nextSource, true);
         syncSelectedImageFromSource(nextSource);
       } catch (yamlError) {
         setSourceYamlError(
-          yamlError instanceof Error ? yamlError.message : 'Invalid source YAML.',
+          yamlError instanceof z.ZodError
+            ? yamlError.issues[0]?.message ?? 'Invalid source YAML.'
+            : yamlError instanceof Error
+              ? yamlError.message
+              : 'Invalid source YAML.',
         );
       }
     },

--- a/app/(main)/instance/_components/management/rebuild.tsx
+++ b/app/(main)/instance/_components/management/rebuild.tsx
@@ -221,11 +221,19 @@ export default function Rebuild({
       return;
     }
 
-    initializedDefaultSourceRef.current = true;
     setRebuildMode('image');
     updateYamlSourceOverride(defaultRebuildSource);
-    syncSelectedImageFromSource(defaultRebuildSource);
-  }, [defaultRebuildSource, syncSelectedImageFromSource, updateYamlSourceOverride]);
+
+    if (localImagesData !== undefined) {
+      syncSelectedImageFromSource(defaultRebuildSource);
+      initializedDefaultSourceRef.current = true;
+    }
+  }, [
+    defaultRebuildSource,
+    localImagesData,
+    syncSelectedImageFromSource,
+    updateYamlSourceOverride,
+  ]);
 
   const handleSourceYamlChange = React.useCallback(
     (value: string | undefined) => {

--- a/app/(main)/instance/_components/management/rebuild.tsx
+++ b/app/(main)/instance/_components/management/rebuild.tsx
@@ -1,0 +1,450 @@
+'use client';
+
+import * as React from 'react';
+
+import ImageSelector, {
+  type SelectableImage,
+} from '@/app/(main)/_components/image-selector';
+import { useImages } from '@/app/(main)/images/_hooks/images';
+import type { Instance } from '@/app/(main)/instances/_lib/instances.d';
+import { fromYaml, toYaml } from '@/app/(main)/_lib/yaml';
+import { Button } from 'ui-web/components/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from 'ui-web/components/select';
+import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
+import { CodeXmlIcon } from 'lucide-react';
+import { rebuildInstance, type AdvancedInstanceRebuildSource } from '../../_lib/instance';
+import { SettingsYamlEditor } from '../settings-yaml-editor';
+import { ManagementFooter } from './footer';
+
+type RebuildMode = 'image' | 'empty';
+
+export default function Rebuild({
+  instance,
+  onBack,
+  onDone,
+}: {
+  instance: Instance;
+  onBack: () => void;
+  onDone: () => Promise<void>;
+}) {
+  const { data: localImagesData } = useImages(instance.project ?? null);
+  const [selectedImage, setSelectedImage] = React.useState<SelectableImage | null>(null);
+  const [rebuildMode, setRebuildMode] = React.useState<RebuildMode>('image');
+  const [showSourceYamlEditor, setShowSourceYamlEditor] = React.useState(false);
+  const [sourceYamlContent, setSourceYamlContent] = React.useState('');
+  const [sourceYamlError, setSourceYamlError] = React.useState<string | null>(null);
+  const [yamlSourceOverride, setYamlSourceOverride] =
+    React.useState<AdvancedInstanceRebuildSource | null>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const initializedDefaultSourceRef = React.useRef(false);
+
+  const projectLabel = instance.project
+    ? `Project · ${instance.project}`
+    : 'Project · default';
+  const localSelectableImages = React.useMemo<SelectableImage[]>(() => {
+    if (!localImagesData) {
+      return [];
+    }
+
+    return localImagesData.map((image) => ({
+      id: `local-${image.fingerprint}`,
+      local: true,
+      label:
+        image.aliases?.[0]?.name ?? image.properties.os ?? image.fingerprint,
+      os: image.properties.os,
+      release: image.properties.release,
+      variant: image.properties.variant,
+      arch: image.architecture,
+      types: image.type ? [image.type as 'container' | 'virtual-machine'] : [],
+      fingerprint: image.fingerprint,
+    }));
+  }, [localImagesData]);
+
+  React.useEffect(() => {
+    setSelectedImage(null);
+    setRebuildMode('image');
+    setShowSourceYamlEditor(false);
+    setSourceYamlContent('');
+    setSourceYamlError(null);
+    setYamlSourceOverride(null);
+    setError(null);
+    initializedDefaultSourceRef.current = false;
+  }, [instance.name]);
+
+  const getSelectedImageSource = React.useCallback((): AdvancedInstanceRebuildSource => {
+    if (!selectedImage) {
+      throw new Error('Select an image before rebuilding this instance.');
+    }
+
+    if (selectedImage.local && selectedImage.fingerprint) {
+      return {
+        type: 'image',
+        fingerprint: selectedImage.fingerprint,
+      };
+    }
+
+    if (selectedImage.remote?.alias && selectedImage.remote?.server) {
+      return {
+        type: 'image',
+        alias: selectedImage.remote.alias,
+        server: selectedImage.remote.server,
+        mode: 'pull',
+        protocol: selectedImage.remote.protocol,
+      };
+    }
+
+    throw new Error('The selected image is missing the data needed for rebuild.');
+  }, [selectedImage]);
+
+  const getRebuildSource = React.useCallback((): AdvancedInstanceRebuildSource => {
+    if (yamlSourceOverride) {
+      return yamlSourceOverride;
+    }
+
+    if (rebuildMode === 'empty') {
+      return { type: 'none' };
+    }
+
+    return getSelectedImageSource();
+  }, [getSelectedImageSource, rebuildMode, yamlSourceOverride]);
+
+  const updateYamlSourceOverride = React.useCallback(
+    (
+      nextSource: AdvancedInstanceRebuildSource | null,
+      skipContentUpdate = false,
+    ) => {
+      setYamlSourceOverride(nextSource);
+
+      if (!nextSource) {
+        setSourceYamlError(null);
+        return;
+      }
+
+      if (!skipContentUpdate) {
+        setSourceYamlContent(
+          toYaml(nextSource as unknown as Record<string, unknown>),
+        );
+      }
+      setSourceYamlError(null);
+    },
+    [],
+  );
+
+  const syncSelectedImageFromSource = React.useCallback(
+    (nextSource: AdvancedInstanceRebuildSource) => {
+      if (nextSource.type !== 'image') {
+        setSelectedImage(null);
+        return;
+      }
+
+      if (nextSource.fingerprint) {
+        setSelectedImage((current) => {
+          if (current?.fingerprint === nextSource.fingerprint) {
+            return current;
+          }
+
+          return (
+            localSelectableImages.find(
+              (image) => image.fingerprint === nextSource.fingerprint,
+            ) ?? null
+          );
+        });
+        return;
+      }
+
+      if (nextSource.alias && nextSource.server) {
+        setSelectedImage((current) =>
+          current?.remote?.alias === nextSource.alias &&
+          current?.remote?.server === nextSource.server
+            ? current
+            : null,
+        );
+        return;
+      }
+
+      setSelectedImage(null);
+    },
+    [localSelectableImages],
+  );
+
+  const defaultRebuildSource = React.useMemo<AdvancedInstanceRebuildSource | null>(() => {
+    const fingerprint =
+      instance.expanded_config?.['volatile.base_image'] ??
+      instance.config?.['volatile.base_image'] ??
+      null;
+    if (fingerprint) {
+      return {
+        type: 'image',
+        fingerprint,
+      };
+    }
+
+    return null;
+  }, [instance.config, instance.expanded_config]);
+
+  React.useEffect(() => {
+    if (initializedDefaultSourceRef.current || !defaultRebuildSource) {
+      return;
+    }
+
+    initializedDefaultSourceRef.current = true;
+    setRebuildMode('image');
+    updateYamlSourceOverride(defaultRebuildSource);
+    syncSelectedImageFromSource(defaultRebuildSource);
+  }, [defaultRebuildSource, syncSelectedImageFromSource, updateYamlSourceOverride]);
+
+  const handleSourceYamlChange = React.useCallback(
+    (value: string | undefined) => {
+      const nextValue = value ?? '';
+      setSourceYamlContent(nextValue);
+
+      try {
+        const parsed = fromYaml(nextValue);
+        if (!parsed || typeof parsed !== 'object') {
+          throw new Error('Invalid source YAML.');
+        }
+        const parsedSource = parsed as Record<string, unknown>;
+        const type = parsedSource.type;
+
+        if (type !== 'image' && type !== 'none') {
+          throw new Error('Source YAML must include type: image or type: none.');
+        }
+
+        if (type === 'none') {
+          const nextSource: AdvancedInstanceRebuildSource = { type: 'none' };
+          setRebuildMode('empty');
+          updateYamlSourceOverride(nextSource, true);
+          syncSelectedImageFromSource(nextSource);
+          return;
+        }
+
+        const fingerprint =
+          typeof parsedSource.fingerprint === 'string' &&
+          parsedSource.fingerprint.trim()
+            ? parsedSource.fingerprint.trim()
+            : undefined;
+        const alias =
+          typeof parsedSource.alias === 'string' && parsedSource.alias.trim()
+            ? parsedSource.alias.trim()
+            : undefined;
+        const server =
+          typeof parsedSource.server === 'string' && parsedSource.server.trim()
+            ? parsedSource.server.trim()
+            : undefined;
+        const mode = parsedSource.mode;
+        const protocol = parsedSource.protocol;
+
+        if (!fingerprint && !(alias && server)) {
+          throw new Error(
+            'Image source YAML must include fingerprint or both alias and server.',
+          );
+        }
+
+        if (mode !== undefined && mode !== 'pull') {
+          throw new Error('Only mode: pull is supported for rebuild sources.');
+        }
+
+        if (
+          protocol !== undefined &&
+          protocol !== 'simplestreams' &&
+          protocol !== 'oci'
+        ) {
+          throw new Error(
+            'protocol must be either simplestreams or oci when provided.',
+          );
+        }
+
+        const nextSource: AdvancedInstanceRebuildSource = {
+          type: 'image',
+          ...(fingerprint ? { fingerprint } : {}),
+          ...(alias ? { alias } : {}),
+          ...(server ? { server } : {}),
+          ...(mode === 'pull' ? { mode } : {}),
+          ...(protocol ? { protocol } : {}),
+        };
+
+        setRebuildMode('image');
+        updateYamlSourceOverride(nextSource, true);
+        syncSelectedImageFromSource(nextSource);
+      } catch (yamlError) {
+        setSourceYamlError(
+          yamlError instanceof Error ? yamlError.message : 'Invalid source YAML.',
+        );
+      }
+    },
+    [syncSelectedImageFromSource, updateYamlSourceOverride],
+  );
+
+  const handleToggleSourceYamlEditor = React.useCallback(() => {
+    if (!showSourceYamlEditor) {
+      try {
+        const currentSource = getRebuildSource();
+        setSourceYamlContent(
+          toYaml(currentSource as unknown as Record<string, unknown>),
+        );
+        setSourceYamlError(null);
+      } catch {
+        setSourceYamlContent(
+          toYaml({ type: rebuildMode } as unknown as Record<string, unknown>),
+        );
+      }
+    }
+
+    setShowSourceYamlEditor((current) => !current);
+  }, [getRebuildSource, rebuildMode, showSourceYamlEditor]);
+
+  const handleRebuildModeChange = React.useCallback(
+    (nextMode: RebuildMode) => {
+      setRebuildMode(nextMode);
+      setSourceYamlError(null);
+
+      if (nextMode === 'empty') {
+        const emptySource: AdvancedInstanceRebuildSource = { type: 'none' };
+        updateYamlSourceOverride(emptySource);
+        setSourceYamlContent(toYaml(emptySource as Record<string, unknown>));
+        return;
+      }
+
+      updateYamlSourceOverride(null);
+
+      try {
+        const imageSource = getSelectedImageSource();
+        setSourceYamlContent(toYaml(imageSource as Record<string, unknown>));
+      } catch {
+        setSourceYamlContent(toYaml({ type: 'image' } as Record<string, unknown>));
+      }
+    },
+    [getSelectedImageSource, updateYamlSourceOverride],
+  );
+
+  const handleRebuildImageSelect = React.useCallback(
+    (image: SelectableImage) => {
+      setSelectedImage(image);
+      updateYamlSourceOverride(null);
+      setSourceYamlError(null);
+    },
+    [updateYamlSourceOverride],
+  );
+
+  const handleRebuild = async () => {
+    try {
+      setError(null);
+      setIsSaving(true);
+      const source = getRebuildSource();
+      await rebuildInstance({ instance, source });
+      await onDone();
+    } catch (rebuildError) {
+      setError(
+        rebuildError instanceof Error
+          ? rebuildError.message
+          : 'Unable to rebuild instance.',
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Action failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {!showSourceYamlEditor ? (
+          <div className="mb-4 grid gap-2">
+            <p className="text-sm font-medium">Rebuild source</p>
+            <Select
+              value={rebuildMode}
+              onValueChange={(value) =>
+                handleRebuildModeChange(value as RebuildMode)
+              }
+              disabled={isSaving}
+            >
+              <SelectTrigger className="w-full sm:w-64">
+                <SelectValue placeholder="Select rebuild source" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="image">Image</SelectItem>
+                <SelectItem value="empty">Empty rebuild</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+
+        {rebuildMode === 'image' ? (
+          <div className="flex h-full min-h-0 flex-col overflow-hidden">
+            {showSourceYamlEditor ? (
+              <SettingsYamlEditor
+                value={sourceYamlContent}
+                error={sourceYamlError}
+                onChange={handleSourceYamlChange}
+                className="h-full"
+              />
+            ) : (
+              <ImageSelector
+                selectedImage={selectedImage}
+                onSelect={handleRebuildImageSelect}
+                instanceType={
+                  instance.type === 'virtual-machine'
+                    ? 'virtual-machine'
+                    : 'container'
+                }
+                project={instance.project ?? null}
+                projectLabel={projectLabel}
+                emptyDescription="Select the image to use for the rebuild."
+                defaultSelection={{
+                  fingerprint:
+                    instance.expanded_config?.['volatile.base_image'] ??
+                    instance.config?.['volatile.base_image'] ??
+                    null,
+                  alias: instance.config?.['image.alias'] ?? null,
+                  description: instance.config?.['image.description'] ?? null,
+                }}
+                disableAutoSelect={showSourceYamlEditor}
+              />
+            )}
+          </div>
+        ) : (
+          <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+            An empty rebuild recreates the instance without selecting an image source.
+          </div>
+        )}
+      </div>
+
+      <ManagementFooter
+        left={
+          rebuildMode === 'image' ? (
+            <Button
+              variant="outline"
+              onClick={handleToggleSourceYamlEditor}
+              disabled={isSaving}
+            >
+              <CodeXmlIcon className="mr-2 h-4 w-4" />
+              {showSourceYamlEditor ? 'Back to Wizard' : 'Edit YAML'}
+            </Button>
+          ) : null
+        }
+        onBack={onBack}
+        backDisabled={isSaving}
+        primaryLabel="Rebuild Instance"
+        onPrimary={handleRebuild}
+        primaryDisabled={
+          Boolean(sourceYamlError) ||
+          (rebuildMode === 'image' && !selectedImage && !yamlSourceOverride)
+        }
+        primaryLoading={isSaving}
+      />
+    </div>
+  );
+}

--- a/app/(main)/instance/_components/management/repair.tsx
+++ b/app/(main)/instance/_components/management/repair.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import * as React from 'react';
+
+import type { Instance } from '@/app/(main)/instances/_lib/instances.d';
+import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
+import { Badge } from 'ui-web/components/badge';
+import { repairInstance } from '../../_lib/instance';
+import { ManagementFooter } from './footer';
+
+export default function Repair({
+  instance,
+  onBack,
+  onDone,
+}: {
+  instance: Instance;
+  onBack: () => void;
+  onDone: () => Promise<void>;
+}) {
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleRepair = async () => {
+    try {
+      setError(null);
+      setIsSaving(true);
+      await repairInstance({
+        instance,
+        action: 'rebuild-config-volume',
+      });
+      await onDone();
+    } catch (repairError) {
+      setError(
+        repairError instanceof Error
+          ? repairError.message
+          : 'Unable to repair instance.',
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Action failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="rounded-md border bg-muted/30 p-4 text-sm">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">Supported action</span>
+          <Badge variant="outline">rebuild-config-volume</Badge>
+        </div>
+        <p className="mt-2 text-muted-foreground">
+          This triggers the currently supported low-level repair action exposed by
+          Incus for this instance.
+        </p>
+      </div>
+
+      <ManagementFooter
+        onBack={onBack}
+        backDisabled={isSaving}
+        primaryLabel="Run repair"
+        onPrimary={handleRepair}
+        primaryLoading={isSaving}
+      />
+    </div>
+  );
+}

--- a/app/(main)/instance/_components/management/shell.tsx
+++ b/app/(main)/instance/_components/management/shell.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import * as React from 'react';
+
+import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
+import { cn } from 'ui-web/lib/utils';
+
+export function ManagementShell({
+  children,
+  footer,
+  error,
+  className,
+  fillHeight = true,
+}: {
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  error?: string | null;
+  className?: string;
+  fillHeight?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex min-h-0 flex-col overflow-hidden',
+        fillHeight && 'h-full flex-1',
+        className,
+      )}
+    >
+      {error ? (
+        <Alert variant="destructive" className="mb-4">
+          <AlertTitle>Save failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      <div className={cn('min-h-0', fillHeight && 'flex-1 overflow-hidden')}>
+        {children}
+      </div>
+      {footer}
+    </div>
+  );
+}

--- a/app/(main)/instance/_components/settings-yaml-editor.tsx
+++ b/app/(main)/instance/_components/settings-yaml-editor.tsx
@@ -3,12 +3,14 @@
 import * as React from 'react';
 import Editor from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
+import { cn } from 'ui-web/lib/utils';
 
 interface SettingsYamlEditorProps {
   value: string;
   error: string | null;
   onChange: (value: string | undefined) => void;
   description?: string;
+  className?: string;
 }
 
 export function SettingsYamlEditor({
@@ -16,11 +18,12 @@ export function SettingsYamlEditor({
   error,
   onChange,
   description,
+  className,
 }: SettingsYamlEditorProps) {
   const { resolvedTheme } = useTheme();
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className={cn('flex min-h-[22rem] flex-col overflow-hidden', className)}>
       {description || error ? (
         <div className="border-b px-6 py-4">
           {description ? (

--- a/app/(main)/instance/_components/settings-yaml-editor.tsx
+++ b/app/(main)/instance/_components/settings-yaml-editor.tsx
@@ -8,7 +8,7 @@ interface SettingsYamlEditorProps {
   value: string;
   error: string | null;
   onChange: (value: string | undefined) => void;
-  description: string;
+  description?: string;
 }
 
 export function SettingsYamlEditor({
@@ -21,10 +21,16 @@ export function SettingsYamlEditor({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="border-b px-6 py-4">
-        <p className="text-muted-foreground text-sm">{description}</p>
-        {error ? <p className="text-destructive mt-2 text-sm">{error}</p> : null}
-      </div>
+      {description || error ? (
+        <div className="border-b px-6 py-4">
+          {description ? (
+            <p className="text-muted-foreground text-sm">{description}</p>
+          ) : null}
+          {error ? (
+            <p className="text-destructive mt-2 text-sm">{error}</p>
+          ) : null}
+        </div>
+      ) : null}
       <div className="min-h-0 flex-1 overflow-hidden">
         <Editor
           height="100%"

--- a/app/(main)/instance/_lib/instance.ts
+++ b/app/(main)/instance/_lib/instance.ts
@@ -5,6 +5,19 @@ import { jsonFetcherWithResponse } from '@/app/_lib/fetcher';
 import type { StandardResponse } from '@/app/_lib/response.d';
 
 export type InstanceAction = 'start' | 'stop' | 'restart' | 'freeze';
+export type AdvancedInstanceRepairAction = 'rebuild-config-volume';
+export type AdvancedInstanceRebuildSource =
+  | {
+      type: 'none';
+    }
+  | {
+      type: 'image';
+      fingerprint?: string;
+      alias?: string;
+      server?: string;
+      mode?: 'pull';
+      protocol?: 'simplestreams' | 'oci';
+    };
 const OPERATION_TIMEOUT_MS = 30000;
 
 interface UpdateInstanceMetadataInput {
@@ -40,15 +53,50 @@ interface UpdateInstanceBody {
   profiles: string[];
 }
 
+interface OperationResponseBody {
+  type?: string;
+  error?: string;
+  operation?: string;
+}
+
 function getProjectSuffix(instance: Instance) {
   return instance.project
     ? `?project=${encodeURIComponent(instance.project)}`
     : '';
 }
 
+function getProjectParam(instance: Instance) {
+  const params = new URLSearchParams();
+  if (instance.project) {
+    params.set('project', instance.project);
+  }
+
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
 async function getErrorMessage(res: Response, fallback: string) {
   const payload = await res.json().catch(() => ({ error: res.statusText }));
   return payload?.error || fallback;
+}
+
+async function parseOperationResponse(
+  res: Response,
+  fallback: string,
+): Promise<OperationResponseBody | null> {
+  const payload = (await res
+    .json()
+    .catch(() => null)) as OperationResponseBody | null;
+
+  if (!res.ok) {
+    throw new Error(payload?.error || fallback);
+  }
+
+  if (payload?.type === 'error') {
+    throw new Error(payload.error || fallback);
+  }
+
+  return payload;
 }
 
 async function getInstanceForUpdate({
@@ -106,9 +154,11 @@ function buildInstanceUpdateBody({
 
 export async function performInstanceAction({
   action,
+  force = false,
   instance,
 }: {
   action: InstanceAction;
+  force?: boolean;
   instance: Instance;
 }) {
   const projectSuffix = getProjectSuffix(instance);
@@ -122,17 +172,116 @@ export async function performInstanceAction({
       body: JSON.stringify({
         action,
         timeout: 30,
-        force: false,
+        force,
         stateful: false,
       }),
     },
   );
-  if (!res.ok) {
-    const payload = await res.json().catch(() => ({ error: res.statusText }));
-    throw new Error(
-      payload?.error || `Unable to ${action} instance ${instance.name}`,
-    );
+  const payload = await parseOperationResponse(
+    res,
+    `Unable to ${action} instance ${instance.name}`,
+  );
+
+  if (payload?.operation) {
+    await waitForOperation({
+      operation: payload.operation,
+      project: instance.project,
+    });
   }
+}
+
+export function isInstanceDeleteProtected(instance: Instance) {
+  const config = instance.expanded_config ?? instance.config ?? {};
+  return config['security.protection.delete'] === 'true';
+}
+
+export function isInstanceRunning(instance: Instance) {
+  const status = instance.status?.toLowerCase();
+  return status === 'running' || status === 'started';
+}
+
+export function canDeleteInstance(instance: Instance) {
+  return !isInstanceDeleteProtected(instance) && !isInstanceRunning(instance);
+}
+
+export async function deleteInstance(instance: Instance, force = false) {
+  if (force && isInstanceRunning(instance)) {
+    await performInstanceAction({
+      action: 'stop',
+      force: true,
+      instance,
+    });
+  }
+
+  const projectParam = getProjectParam(instance);
+  const res = await fetch(
+    `/1.0/instances/${encodeURIComponent(instance.name)}${projectParam}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  return parseOperationResponse(
+    res,
+    `Unable to delete instance ${instance.name}.`,
+  );
+}
+
+export async function rebuildInstance({
+  instance,
+  source,
+}: {
+  instance: Instance;
+  source: AdvancedInstanceRebuildSource;
+}) {
+  const projectParam = getProjectParam(instance);
+  const res = await fetch(
+    `/1.0/instances/${encodeURIComponent(instance.name)}/rebuild${projectParam}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        source,
+      }),
+    },
+  );
+
+  return parseOperationResponse(
+    res,
+    `Unable to rebuild instance ${instance.name}.`,
+  );
+}
+
+export async function repairInstance({
+  instance,
+  action,
+}: {
+  instance: Instance;
+  action: AdvancedInstanceRepairAction;
+}) {
+  const projectParam = getProjectParam(instance);
+  const res = await fetch(
+    `/1.0/instances/${encodeURIComponent(instance.name)}/debug/repair${projectParam}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        action,
+      }),
+    },
+  );
+
+  return parseOperationResponse(
+    res,
+    `Unable to repair instance ${instance.name}.`,
+  );
 }
 
 async function updateInstanceDescription({

--- a/app/(main)/instance/_lib/instance.ts
+++ b/app/(main)/instance/_lib/instance.ts
@@ -6,6 +6,14 @@ import type { StandardResponse } from '@/app/_lib/response.d';
 
 export type InstanceAction = 'start' | 'stop' | 'restart' | 'freeze';
 export type AdvancedInstanceRepairAction = 'rebuild-config-volume';
+export interface CloneInstanceInput {
+  instance: Instance;
+  name: string;
+  targetProject: string;
+  rootStoragePool: string;
+  allowInconsistent: boolean;
+  instanceOnly: boolean;
+}
 export type AdvancedInstanceRebuildSource =
   | {
       type: 'none';
@@ -31,6 +39,7 @@ interface UpdateInstanceSettingsInput {
   instance: Instance;
   nextConfig?: Record<string, string>;
   nextDevices?: Record<string, Device>;
+  nextProfiles?: string[];
   signal?: AbortSignal;
 }
 
@@ -59,10 +68,12 @@ interface OperationResponseBody {
   operation?: string;
 }
 
+function getProjectQuery(project?: string | null) {
+  return project ? `?project=${encodeURIComponent(project)}` : '';
+}
+
 function getProjectSuffix(instance: Instance) {
-  return instance.project
-    ? `?project=${encodeURIComponent(instance.project)}`
-    : '';
+  return getProjectQuery(instance.project);
 }
 
 function getProjectParam(instance: Instance) {
@@ -133,15 +144,17 @@ function buildInstanceUpdateBody({
   instance,
   nextConfig,
   nextDevices,
+  nextProfiles,
 }: {
   instance: Instance;
   nextConfig?: Record<string, string>;
   nextDevices?: Record<string, Device>;
+  nextProfiles?: string[];
 }) {
   const payload: UpdateInstanceBody = {
     config: nextConfig ?? instance.config ?? {},
     devices: nextDevices ?? (instance.devices as Record<string, Device>) ?? {},
-    profiles: instance.profiles ?? ['default'],
+    profiles: nextProfiles ?? instance.profiles ?? ['default'],
   };
 
   if (instance.architecture) {
@@ -298,6 +311,71 @@ export async function repairInstance({
   );
 
   await waitForOperationIfNeeded({ payload, instance });
+
+  return payload;
+}
+
+export async function cloneInstance({
+  instance,
+  name,
+  targetProject,
+  rootStoragePool,
+  allowInconsistent,
+  instanceOnly,
+}: CloneInstanceInput) {
+  const normalizedName = name.trim();
+  const normalizedTargetProject = targetProject.trim();
+  const normalizedRootStoragePool = rootStoragePool.trim();
+
+  if (!normalizedName) {
+    throw new Error('Clone name is required.');
+  }
+
+  if (!normalizedRootStoragePool) {
+    throw new Error('Root storage pool is required.');
+  }
+
+  const sourceRootDevice =
+    (instance.expanded_devices?.root as Device | undefined) ??
+    (instance.devices?.root as Device | undefined);
+
+  const res = await fetch(`/1.0/instances${getProjectQuery(normalizedTargetProject)}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: normalizedName,
+      type: instance.type,
+      devices: {
+        root: {
+          ...(sourceRootDevice ?? {}),
+          type: sourceRootDevice?.type ?? 'disk',
+          path: sourceRootDevice?.path ?? '/',
+          pool: normalizedRootStoragePool,
+        },
+      },
+      source: {
+        type: 'copy',
+        source: instance.name,
+        ...(instance.project ? { project: instance.project } : {}),
+        allow_inconsistent: allowInconsistent,
+        instance_only: instanceOnly,
+      },
+    }),
+  });
+
+  const payload = await parseOperationResponse(
+    res,
+    `Unable to clone instance ${instance.name}.`,
+  );
+
+  if (payload?.operation) {
+    await waitForOperation({
+      operation: payload.operation,
+      project: normalizedTargetProject,
+    });
+  }
 
   return payload;
 }
@@ -473,6 +551,7 @@ export async function updateInstanceSettings({
   instance,
   nextConfig,
   nextDevices,
+  nextProfiles,
   signal,
 }: UpdateInstanceSettingsInput) {
   const { instance: latestInstance, etag } = await getInstanceForUpdate({
@@ -484,6 +563,7 @@ export async function updateInstanceSettings({
     instance: latestInstance,
     nextConfig,
     nextDevices,
+    nextProfiles,
   });
 
   const res = await fetch(

--- a/app/(main)/instance/_lib/instance.ts
+++ b/app/(main)/instance/_lib/instance.ts
@@ -66,13 +66,7 @@ function getProjectSuffix(instance: Instance) {
 }
 
 function getProjectParam(instance: Instance) {
-  const params = new URLSearchParams();
-  if (instance.project) {
-    params.set('project', instance.project);
-  }
-
-  const query = params.toString();
-  return query ? `?${query}` : '';
+  return getProjectSuffix(instance);
 }
 
 async function getErrorMessage(res: Response, fallback: string) {
@@ -97,6 +91,23 @@ async function parseOperationResponse(
   }
 
   return payload;
+}
+
+async function waitForOperationIfNeeded({
+  payload,
+  instance,
+}: {
+  payload: OperationResponseBody | null;
+  instance: Instance;
+}) {
+  if (!payload?.operation) {
+    return;
+  }
+
+  await waitForOperation({
+    operation: payload.operation,
+    project: instance.project,
+  });
 }
 
 async function getInstanceForUpdate({
@@ -182,12 +193,7 @@ export async function performInstanceAction({
     `Unable to ${action} instance ${instance.name}`,
   );
 
-  if (payload?.operation) {
-    await waitForOperation({
-      operation: payload.operation,
-      project: instance.project,
-    });
-  }
+  await waitForOperationIfNeeded({ payload, instance });
 }
 
 export function isInstanceDeleteProtected(instance: Instance) {
@@ -224,10 +230,14 @@ export async function deleteInstance(instance: Instance, force = false) {
     },
   );
 
-  return parseOperationResponse(
+  const payload = await parseOperationResponse(
     res,
     `Unable to delete instance ${instance.name}.`,
   );
+
+  await waitForOperationIfNeeded({ payload, instance });
+
+  return payload;
 }
 
 export async function rebuildInstance({
@@ -251,10 +261,14 @@ export async function rebuildInstance({
     },
   );
 
-  return parseOperationResponse(
+  const payload = await parseOperationResponse(
     res,
     `Unable to rebuild instance ${instance.name}.`,
   );
+
+  await waitForOperationIfNeeded({ payload, instance });
+
+  return payload;
 }
 
 export async function repairInstance({
@@ -278,10 +292,14 @@ export async function repairInstance({
     },
   );
 
-  return parseOperationResponse(
+  const payload = await parseOperationResponse(
     res,
     `Unable to repair instance ${instance.name}.`,
   );
+
+  await waitForOperationIfNeeded({ payload, instance });
+
+  return payload;
 }
 
 async function updateInstanceDescription({

--- a/app/(main)/instance/_lib/instance.ts
+++ b/app/(main)/instance/_lib/instance.ts
@@ -358,7 +358,7 @@ export async function cloneInstance({
       source: {
         type: 'copy',
         source: instance.name,
-        ...(instance.project ? { project: instance.project } : {}),
+        project: instance.project ?? 'default',
         allow_inconsistent: allowInconsistent,
         instance_only: instanceOnly,
       },

--- a/app/(main)/instance/layout.tsx
+++ b/app/(main)/instance/layout.tsx
@@ -27,14 +27,14 @@ import {
   XIcon,
 } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger } from 'ui-web/components/tabs';
-import { OSLogo } from '@/app/_components/OSLogo';
-import { getBaseImage } from './_lib/utils';
 import {
   performInstanceAction,
   updateInstanceMetadata,
   type InstanceAction,
 } from './_lib/instance';
 import { SiteHeader } from '@/app/(main)/_components/header';
+import { InstanceActionsMenu } from './_components/instance-actions-menu';
+import IsClientContext from '@/app/_context/isClient';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -47,6 +47,7 @@ import { cn } from 'ui-web/lib/utils';
 import Link from 'next/link';
 
 function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
+  const isClient = React.use(IsClientContext);
   const { name, instance, isLoading, isError, mutate } = useInstanceContext();
 
   const pathname = usePathname();
@@ -64,17 +65,17 @@ function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
     if (!name) {
       return (
         <div className="h-full overflow-auto p-6">
-            <Alert variant="destructive">
-              <AlertTitle>Missing Parameter</AlertTitle>
-              <AlertDescription>
-                The <code>name</code> query parameter is required.
-              </AlertDescription>
-            </Alert>
-          </div>
+          <Alert variant="destructive">
+            <AlertTitle>Missing Parameter</AlertTitle>
+            <AlertDescription>
+              The <code>name</code> query parameter is required.
+            </AlertDescription>
+          </Alert>
+        </div>
       );
     }
 
-    if (isLoading && !instance) {
+    if (!isClient || (isLoading && !instance)) {
       return (
         <div className="flex h-full items-center justify-center p-8">
           <Spinner className="size-8" />
@@ -110,7 +111,7 @@ function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <SiteHeader>
-<Breadcrumb className="select-none">
+        <Breadcrumb className="select-none">
           <BreadcrumbList>
             <BreadcrumbItem>
               <BreadcrumbLink asChild>
@@ -134,7 +135,9 @@ function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
           </BreadcrumbList>
         </Breadcrumb>
       </SiteHeader>
-      <div className="min-h-0 flex-1 overflow-auto">{renderContent()}</div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+        {renderContent()}
+      </div>
     </div>
   );
 }
@@ -355,8 +358,6 @@ function InstanceHeader({
     availableActions.push('start');
   }
 
-  const isUnknownStatus = !isRunning && !isStopped && !isFrozen;
-
   const renderEditableField = ({
     field,
     value,
@@ -459,27 +460,11 @@ function InstanceHeader({
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-4">
-        <div className="relative flex h-16 w-16 items-center justify-center rounded-lg border bg-muted">
-          <OSLogo brand={getBaseImage(instance)} className="h-8 w-8" />
-
-          {/* Pulsing Status Circle */}
-          {isRunning && (
-            <span className="absolute -bottom-1 -right-1 flex h-4 w-4">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
-              <span className="relative inline-flex rounded-full h-4 w-4 bg-green-500"></span>
-            </span>
-          )}
-          {isUnknownStatus && (
-            <span className="absolute -bottom-1 -right-1 flex h-4 w-4">
-              <span className="relative inline-flex rounded-full h-4 w-4 bg-gray-400"></span>
-            </span>
-          )}
-          {isStopped && (
-            <span className="absolute -bottom-1 -right-1 flex h-4 w-4">
-              <span className="relative inline-flex rounded-full h-4 w-4 bg-red-500"></span>
-            </span>
-          )}
-        </div>
+        <InstanceActionsMenu
+          instance={instance}
+          disabled={isBusy}
+          onMutate={onMutate}
+        />
 
         <div ref={fieldContainerRef} className="flex-1 space-y-1">
           {renderEditableField({

--- a/app/(main)/instance/layout.tsx
+++ b/app/(main)/instance/layout.tsx
@@ -20,8 +20,6 @@ import {
   Terminal,
   Folder,
   Camera,
-  Cpu,
-  Settings,
   PencilIcon,
   CheckIcon,
   XIcon,
@@ -525,12 +523,10 @@ function InstanceHeader({
 
 const TABS = [
   { value: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-  { value: 'backups', label: 'Backups', icon: Archive },
   { value: 'console', label: 'Console', icon: Terminal },
   { value: 'files', label: 'Files', icon: Folder },
   { value: 'snapshots', label: 'Snapshots', icon: Camera },
-  { value: 'devices', label: 'Devices', icon: Cpu },
-  { value: 'configuration', label: 'Configuration', icon: Settings },
+  { value: 'backups', label: 'Backups', icon: Archive },
 ];
 
 function InstanceTabs() {

--- a/app/(main)/instance/page.tsx
+++ b/app/(main)/instance/page.tsx
@@ -85,6 +85,12 @@ export default function InstancePage() {
   const networkDetails = getNetworkDetails(instance);
   const baseImage = getBaseImage(instance);
   const rootDiskPool = getRootDiskPool(instance);
+  const instanceType =
+    instance.type === 'virtual-machine'
+      ? 'Virtual Machine'
+      : instance.type === 'container'
+        ? 'Container'
+        : (instance.type ?? '—');
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -192,6 +198,10 @@ export default function InstancePage() {
           <div className="flex justify-between">
             <span className="text-muted-foreground">Project</span>
             <span>{instance.project ?? 'default'}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Type</span>
+            <span>{instanceType}</span>
           </div>
           <div className="flex justify-between">
             <span className="text-muted-foreground">Base Image</span>

--- a/app/(main)/instance/page.tsx
+++ b/app/(main)/instance/page.tsx
@@ -25,35 +25,20 @@ import {
 
 export default function InstancePage() {
   const { instance, isLoading } = useInstanceContext();
-
-  if (isLoading) {
-    return <Spinner />;
-  }
-
-  if (!instance) {
-    return null; // Layout handles error display
-  }
-
-  // Dashboard content inlined
-
-  const memoryUsage = instance.state?.memory?.usage ?? 0;
-  const memoryTotal =
-    instance.state?.memory?.total ?? instance.state?.memory?.usage_peak;
-  const memoryPercent = calcResourcePercent(memoryUsage, memoryTotal);
-
-  const diskUsage = getRootDiskUsage(instance.state) ?? 0;
-  const diskTotal = instance.state?.disk?.root?.total;
-  const diskPercent = calcResourcePercent(diskUsage, diskTotal);
-
-  const networkDetails = getNetworkDetails(instance);
-  const baseImage = getBaseImage(instance);
-  const rootDiskPool = getRootDiskPool(instance);
-
   const [cpuPercent, setCpuPercent] = React.useState<number>(0);
   const lastCpuUsage = React.useRef<number | null>(null);
   const lastTime = React.useRef<number | null>(null);
 
+  const currentCpuUsage = instance?.state?.cpu?.usage;
+
   React.useEffect(() => {
+    if (!instance) {
+      lastCpuUsage.current = null;
+      lastTime.current = null;
+      setCpuPercent(0);
+      return;
+    }
+
     const currentUsage = instance.state?.cpu?.usage;
     const currentTime = Date.now();
 
@@ -78,7 +63,28 @@ export default function InstancePage() {
       lastCpuUsage.current = currentUsage;
       lastTime.current = currentTime;
     }
-  }, [instance.state?.cpu?.usage]);
+  }, [currentCpuUsage, instance]);
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (!instance) {
+    return null; // Layout handles error display
+  }
+
+  const memoryUsage = instance.state?.memory?.usage ?? 0;
+  const memoryTotal =
+    instance.state?.memory?.total ?? instance.state?.memory?.usage_peak;
+  const memoryPercent = calcResourcePercent(memoryUsage, memoryTotal);
+
+  const diskUsage = getRootDiskUsage(instance.state) ?? 0;
+  const diskTotal = instance.state?.disk?.root?.total;
+  const diskPercent = calcResourcePercent(diskUsage, diskTotal);
+
+  const networkDetails = getNetworkDetails(instance);
+  const baseImage = getBaseImage(instance);
+  const rootDiskPool = getRootDiskPool(instance);
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/app/(main)/instances/_components/create.tsx
+++ b/app/(main)/instances/_components/create.tsx
@@ -62,6 +62,7 @@ import Editor, { OnMount } from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
 import { mutate } from 'swr';
 import type * as Monaco from 'monaco-editor';
+import { CodeXmlIcon } from 'lucide-react';
 import { cn } from 'ui-web/lib/utils';
 
 const sourceSchema = z
@@ -589,12 +590,11 @@ export default function CreateInstance({ className }: { className?: string }) {
                 <div className="flex w-full items-center justify-between">
                   <Button
                     type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="text-muted-foreground"
+                    variant="outline"
                     onClick={toggleYamlEditor}
                   >
-                    {showYamlEditor ? 'Back to wizard' : 'Edit YAML'}
+                    <CodeXmlIcon className="mr-2 size-4" />
+                    {showYamlEditor ? 'Back to Wizard' : 'Edit YAML'}
                   </Button>
                   <Button
                     type="submit"

--- a/app/(main)/instances/_components/create.tsx
+++ b/app/(main)/instances/_components/create.tsx
@@ -30,7 +30,9 @@ import { useState, useMemo, use, useCallback, useRef } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import z from 'zod';
-import ImageSelector, { SelectableImage } from './imageSelector';
+import ImageSelector, {
+  type SelectableImage,
+} from '@/app/(main)/_components/image-selector';
 import InstanceProperties from '@/app/(main)/instances/_components/properties';
 import InstanceDevices from './devices';
 import type { Device } from '@/app/(main)/instances/_lib/instances.d';

--- a/app/globals.css
+++ b/app/globals.css
@@ -126,3 +126,18 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes status-halo-pulse {
+  0% {
+    transform: scale(1.15);
+    opacity: 0.4;
+  }
+  18% {
+    transform: scale(2.35);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(2.35);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
Introduce a full InstanceActionsMenu component to manage rebuild, repair and delete flows (UI, dialogs, YAML editing). Add advanced instance APIs and helpers (rebuild, repair, delete, force stop, operation parsing, project query param helpers, and status helpers) in instance lib. Rename and refactor ImageSelector (path change), add project/default labels, defaultSelection matching and auto-select behavior, restrict remote images to simplestreams, and various UI/UX tweaks (layout, classes, table behavior). Make SettingsYamlEditor description optional and render conditionally. Update layout to use the new actions menu and adjust client-only rendering, fix CPU percent effect in instance page, and update imports to the new image-selector path.