### PR TITLE
Instance Creation from Backup Import

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,13 +1,25 @@
 name: DCO Verification
+
 on:
   pull_request:
-    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   dco_check:
+    name: Check DCO
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR commits
+        id: get-pr-commits
+        uses: tim-actions/get-pr-commits@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check DCO
         uses: tim-actions/dco@master
         with:
-          fail_block: true
+          commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/app/(main)/_lib/instance.ts
+++ b/app/(main)/_lib/instance.ts
@@ -1,7 +1,16 @@
+import { buildApiPath } from '@/app/_lib/url';
+
 export default class Instance {
   name: string;
-  constructor(name: string) {
+  project: string | null;
+
+  constructor(name: string, project?: string | null) {
     this.name = name;
+    this.project = project ?? null;
+  }
+
+  private buildPath(path: string) {
+    return buildApiPath(path, { project: this.project });
   }
 
   async openConsoleSocket(
@@ -9,7 +18,7 @@ export default class Instance {
     options?: { width?: number; height?: number },
   ) {
     const response = await fetch(
-      `/1.0/instances/${encodeURIComponent(this.name)}/console`,
+      this.buildPath(`/1.0/instances/${encodeURIComponent(this.name)}/console`),
       {
         method: 'POST',
         body: JSON.stringify({
@@ -45,7 +54,7 @@ export default class Instance {
 
   async openExecSocket(command: string[]) {
     const response = await fetch(
-      `/1.0/instances/${encodeURIComponent(this.name)}/exec`,
+      this.buildPath(`/1.0/instances/${encodeURIComponent(this.name)}/exec`),
       {
         method: 'POST',
         body: JSON.stringify({
@@ -79,7 +88,7 @@ export default class Instance {
 
   async getConsoleOutput() {
     const response = await fetch(
-      `/1.0/instances/${encodeURIComponent(this.name)}/console`,
+      this.buildPath(`/1.0/instances/${encodeURIComponent(this.name)}/console`),
     );
     if (!response.ok) {
       const errorText = await response.text();

--- a/app/(main)/instance/_context/instance.tsx
+++ b/app/(main)/instance/_context/instance.tsx
@@ -13,6 +13,7 @@ import InstanceClass from '../../_lib/instance';
 
 interface InstanceContextValue {
   name: string | null;
+  project: string | null;
   instance: Instance | undefined;
   isLoading: boolean;
   isError: any;
@@ -23,6 +24,7 @@ interface InstanceContextValue {
 
 const InstanceContext = createContext<InstanceContextValue>({
   name: null,
+  project: null,
   instance: undefined,
   isLoading: true,
   isError: null,
@@ -34,16 +36,21 @@ const InstanceContext = createContext<InstanceContextValue>({
 function InstanceProviderInner({ children }: { children: ReactNode }) {
   const searchParams = useSearchParams();
   const name = searchParams.get('name');
+  const project = searchParams.get('project');
   const { instance, isLoading, isError, mutate, isValidating } =
-    useInstance(name);
+    useInstance(name, project);
   const instanceClass = useMemo(
-    () => (instance ? new InstanceClass(instance.name) : null),
-    [instance]
+    () =>
+      instance
+        ? new InstanceClass(instance.name, instance.project ?? project ?? null)
+        : null,
+    [instance, project]
   );
 
   const value: InstanceContextValue = useMemo(
     () => ({
       name,
+      project,
       instance,
       isLoading,
       isError,
@@ -51,7 +58,7 @@ function InstanceProviderInner({ children }: { children: ReactNode }) {
       mutate,
       instanceClass,
     }),
-    [instance, instanceClass, isError, isLoading, isValidating, mutate, name],
+    [instance, instanceClass, isError, isLoading, isValidating, mutate, name, project],
   );
 
 

--- a/app/(main)/instance/_hooks/backups.ts
+++ b/app/(main)/instance/_hooks/backups.ts
@@ -2,6 +2,7 @@ import useSWR, { useSWRConfig } from 'swr';
 import { jsonFetcher } from '../../../_lib/fetcher';
 import { Backup } from '../../_components/backups';
 import { StandardResponse } from '../../../_lib/response';
+import { buildApiPath } from '@/app/_lib/url';
 import {
   createBackup as apiCreateBackup,
   deleteBackup as apiDeleteBackup,
@@ -9,10 +10,18 @@ import {
   downloadBackup as apiDownloadBackup,
 } from '../_lib/backups';
 
-export function useBackups(instanceName: string) {
+function getBackupsCacheKey(instanceName: string, project?: string | null) {
+  return buildApiPath(`/1.0/instances/${encodeURIComponent(instanceName)}/backups`, {
+    project: project ?? null,
+    params: { recursion: 1 },
+  });
+}
+
+export function useBackups(instanceName: string, project?: string | null) {
   const { mutate } = useSWRConfig();
+  const backupsCacheKey = getBackupsCacheKey(instanceName, project);
   const { data, error, isLoading } = useSWR<StandardResponse<Backup[]>>(
-    `/1.0/instances/${instanceName}/backups?recursion=1`,
+    backupsCacheKey,
     (url: string) => jsonFetcher<Backup[]>(url),
   );
 
@@ -21,22 +30,28 @@ export function useBackups(instanceName: string) {
     instanceOnly?: boolean,
     optimizedStorage?: boolean,
   ) => {
-    await apiCreateBackup(instanceName, name, instanceOnly, optimizedStorage);
-    await mutate(`/1.0/instances/${instanceName}/backups?recursion=1`);
+    await apiCreateBackup(
+      instanceName,
+      project,
+      name,
+      instanceOnly,
+      optimizedStorage,
+    );
+    await mutate(backupsCacheKey);
   };
 
   const deleteBackup = async (backupName: string) => {
-    await apiDeleteBackup(instanceName, backupName);
-    await mutate(`/1.0/instances/${instanceName}/backups?recursion=1`);
+    await apiDeleteBackup(instanceName, project, backupName);
+    await mutate(backupsCacheKey);
   };
 
   const renameBackup = async (oldName: string, newName: string) => {
-    await apiRenameBackup(instanceName, oldName, newName);
-    await mutate(`/1.0/instances/${instanceName}/backups?recursion=1`);
+    await apiRenameBackup(instanceName, project, oldName, newName);
+    await mutate(backupsCacheKey);
   };
 
   const downloadBackup = (backupName: string) => {
-    apiDownloadBackup(instanceName, backupName);
+    apiDownloadBackup(instanceName, project, backupName);
   };
 
   return {

--- a/app/(main)/instance/_hooks/instance.ts
+++ b/app/(main)/instance/_hooks/instance.ts
@@ -2,19 +2,29 @@ import useSWR, { type SWRConfiguration } from 'swr';
 import { Instance } from '../../instances/_lib/instances.d';
 import { StandardResponse } from '../../../_lib/response';
 import { jsonFetcher } from '../../../_lib/fetcher';
+import { buildApiPath } from '@/app/_lib/url';
 
-export function getInstanceCacheKey(name: string | null) {
-  return name ? `/1.0/instances/${encodeURIComponent(name)}?recursion=1` : null;
+export function getInstanceCacheKey(
+  name: string | null,
+  project?: string | null,
+) {
+  return name
+    ? buildApiPath(`/1.0/instances/${encodeURIComponent(name)}`, {
+        project: project ?? null,
+        params: { recursion: 1 },
+      })
+    : null;
 }
 
 export function useInstance(
   name: string | null,
+  project?: string | null,
   config?: SWRConfiguration<StandardResponse<Instance>>,
 ) {
   const { data, error, isLoading, mutate, isValidating } = useSWR<
     StandardResponse<Instance>
   >(
-    getInstanceCacheKey(name),
+    getInstanceCacheKey(name, project),
     (url) => jsonFetcher<Instance>(url),
     config,
   );
@@ -28,10 +38,16 @@ export function useInstance(
   };
 }
 
-export function useInstanceAccess(name: string | null) {
+export function useInstanceAccess(name: string | null, project?: string | null) {
   const { data, error, isLoading, isValidating } = useSWR<
     StandardResponse<string[]>
-  >(name ? `/1.0/instances/${name}/access` : null, (url: string) =>
+  >(
+    name
+      ? buildApiPath(`/1.0/instances/${encodeURIComponent(name)}/access`, {
+          project: project ?? null,
+        })
+      : null,
+    (url: string) =>
     jsonFetcher<string[]>(url),
   );
 

--- a/app/(main)/instance/_lib/backups.ts
+++ b/app/(main)/instance/_lib/backups.ts
@@ -1,10 +1,31 @@
+import { buildApiPath } from '@/app/_lib/url';
+
+function buildInstanceBackupsPath(
+  instanceName: string,
+  project?: string | null,
+  backupName?: string,
+  action?: 'export',
+) {
+  const encodedInstanceName = encodeURIComponent(instanceName);
+  const segments = [`/1.0/instances/${encodedInstanceName}/backups`];
+  if (backupName) {
+    segments.push(encodeURIComponent(backupName));
+  }
+  if (action) {
+    segments.push(action);
+  }
+
+  return buildApiPath(segments.join('/'), { project: project ?? null });
+}
+
 export async function createBackup(
   instanceName: string,
+  project?: string | null,
   name?: string,
   instanceOnly?: boolean,
   optimizedStorage?: boolean,
 ) {
-  const res = await fetch(`/1.0/instances/${instanceName}/backups`, {
+  const res = await fetch(buildInstanceBackupsPath(instanceName, project), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -20,15 +41,16 @@ export async function createBackup(
   }
 }
 
-export async function deleteBackup(instanceName: string, backupName: string) {
+export async function deleteBackup(
+  instanceName: string,
+  project: string | null | undefined,
+  backupName: string,
+) {
   const shortName = backupName.split('/').pop() || '';
 
-  const res = await fetch(
-    `/1.0/instances/${instanceName}/backups/${shortName}`,
-    {
-      method: 'DELETE',
-    },
-  );
+  const res = await fetch(buildInstanceBackupsPath(instanceName, project, shortName), {
+    method: 'DELETE',
+  });
 
   if (!res.ok) {
     const data = await res.json().catch(() => ({}));
@@ -38,18 +60,16 @@ export async function deleteBackup(instanceName: string, backupName: string) {
 
 export async function renameBackup(
   instanceName: string,
+  project: string | null | undefined,
   oldName: string,
   newName: string,
 ) {
   const shortOldName = oldName.split('/').pop() || '';
-  const res = await fetch(
-    `/1.0/instances/${instanceName}/backups/${shortOldName}`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: newName }),
-    },
-  );
+  const res = await fetch(buildInstanceBackupsPath(instanceName, project, shortOldName), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: newName }),
+  });
 
   if (!res.ok) {
     const data = await res.json().catch(() => ({}));
@@ -57,9 +77,13 @@ export async function renameBackup(
   }
 }
 
-export function downloadBackup(instanceName: string, backupName: string) {
+export function downloadBackup(
+  instanceName: string,
+  project: string | null | undefined,
+  backupName: string,
+) {
   const shortName = backupName.split('/').pop() || '';
-  const url = `/1.0/instances/${instanceName}/backups/${shortName}/export`;
+  const url = buildInstanceBackupsPath(instanceName, project, shortName, 'export');
   const link = document.createElement('a');
   link.href = url;
   link.download = `${shortName}.tar.gz`;

--- a/app/(main)/instance/backups/page.tsx
+++ b/app/(main)/instance/backups/page.tsx
@@ -9,7 +9,11 @@ import { Spinner } from 'ui-web/components/spinner';
 import { BackupList } from '../../_components/backups';
 
 export default function BackupsPage() {
-  const { instance, isLoading: isInstanceLoading } = useInstanceContext();
+  const {
+    instance,
+    project,
+    isLoading: isInstanceLoading,
+  } = useInstanceContext();
   const { data: storagePools, isLoading: isStorageLoading } = useStoragePools();
 
   const isLoading = isInstanceLoading || isStorageLoading;
@@ -22,14 +26,22 @@ export default function BackupsPage() {
     return null;
   }
 
-  return <Backups instance={instance} storagePools={storagePools || []} />;
+  return (
+    <Backups
+      instance={instance}
+      project={project}
+      storagePools={storagePools || []}
+    />
+  );
 }
 
 function Backups({
   instance,
+  project,
   storagePools,
 }: {
   instance: any;
+  project: string | null;
   storagePools: any[];
 }) {
   const rootDiskPoolName = getRootDiskPool(instance);
@@ -45,7 +57,7 @@ function Backups({
     deleteBackup,
     renameBackup,
     downloadBackup,
-  } = useBackups(instance.name);
+  } = useBackups(instance.name, instance.project ?? project ?? null);
 
   return (
     <BackupList

--- a/app/(main)/instance/files/_hooks/files.ts
+++ b/app/(main)/instance/files/_hooks/files.ts
@@ -26,6 +26,7 @@ import {
   joinAbsPath,
   normalizeAbsPath,
 } from '../../../_lib/files/path';
+import { buildApiPath } from '@/app/_lib/url';
 import { moveRemoteFile } from '../_lib/move-file-client';
 
 type DirectoryResponse = {
@@ -76,8 +77,15 @@ const directoryFetcher = async (url: string) => {
   throw new Error('NOT_A_DIRECTORY');
 };
 
-function buildFilesCacheKey(instanceName: string, path: string) {
-  return `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(path)}`;
+function buildFilesCacheKey(
+  instanceName: string,
+  path: string,
+  project?: string | null,
+) {
+  return buildApiPath(`/1.0/instances/${encodeURIComponent(instanceName)}/files`, {
+    project: project ?? null,
+    params: { path },
+  });
 }
 
 /** Bounded parallelism for HEAD/metadata fan-out (large dirs + browser connection limits). */
@@ -85,12 +93,13 @@ const METADATA_FETCH_BATCH = 16;
 
 async function fetchEntryMetadata(
   instanceName: string,
+  project: string | null | undefined,
   listingParent: string,
   fileName: string,
 ): Promise<FileWithMetadata> {
   try {
     const filePath = joinAbsPath(listingParent, fileName);
-    const meta = await apiFetchFileMetadata(instanceName, filePath);
+    const meta = await apiFetchFileMetadata(instanceName, project, filePath);
     const type = meta.type ?? undefined;
     return {
       name: fileName,
@@ -108,10 +117,13 @@ async function fetchEntryMetadata(
 /** Directory listing + metadata for breadcrumb peek / one-off previews (not SWR-backed). */
 async function fetchDirectoryEntriesForInstance(
   instanceName: string,
+  project: string | null | undefined,
   dirPath: string,
 ): Promise<FileWithMetadata[]> {
   const normalizedPath = normalizeAbsPath(dirPath);
-  const data = await directoryFetcher(buildFilesCacheKey(instanceName, normalizedPath));
+  const data = await directoryFetcher(
+    buildFilesCacheKey(instanceName, normalizedPath, project),
+  );
   if (!data?.metadata?.length) return [];
   const names = data.metadata as string[];
   const entries: FileWithMetadata[] = names.map((name) => ({ name }));
@@ -119,7 +131,7 @@ async function fetchDirectoryEntriesForInstance(
     const slice = names.slice(i, i + METADATA_FETCH_BATCH);
     const batch = await Promise.all(
       slice.map((fileName) =>
-        fetchEntryMetadata(instanceName, normalizedPath, fileName),
+        fetchEntryMetadata(instanceName, project, normalizedPath, fileName),
       ),
     );
     batch.forEach((row, j) => {
@@ -129,7 +141,11 @@ async function fetchDirectoryEntriesForInstance(
   return entries;
 }
 
-export function useFiles(instanceName: string, path: string) {
+export function useFiles(
+  instanceName: string,
+  path: string,
+  project?: string | null,
+) {
   const { mutate } = useSWRConfig();
   // Ensure path starts with /
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
@@ -146,7 +162,7 @@ export function useFiles(instanceName: string, path: string) {
     isLoading: swrIsLoading,
     isValidating,
   } = useSWR(
-    buildFilesCacheKey(instanceName, normalizedPath),
+    buildFilesCacheKey(instanceName, normalizedPath, project),
     directoryFetcher,
     { keepPreviousData: false },
   );
@@ -204,7 +220,7 @@ export function useFiles(instanceName: string, path: string) {
           const slice = toFetch.slice(i, i + METADATA_FETCH_BATCH);
           const batch = await Promise.all(
             slice.map((fileName) =>
-              fetchEntryMetadata(instanceName, parent, fileName),
+              fetchEntryMetadata(instanceName, project, parent, fileName),
             ),
           );
           batch.forEach((row) =>
@@ -228,7 +244,7 @@ export function useFiles(instanceName: string, path: string) {
         }
       })();
     },
-    [instanceName],
+    [instanceName, project],
   );
 
   useEffect(() => {
@@ -281,40 +297,40 @@ export function useFiles(instanceName: string, path: string) {
     file: File,
     onProgress?: (percent: number | null) => void,
   ) => {
-    await apiUploadFile(instanceName, currentPath, file, onProgress);
-    await mutate(buildFilesCacheKey(instanceName, currentPath));
+    await apiUploadFile(instanceName, project, currentPath, file, onProgress);
+    await mutate(buildFilesCacheKey(instanceName, currentPath, project));
   };
 
   const createEmptyFile = async (currentPath: string, fileName: string) => {
-    await apiCreateEmptyFile(instanceName, currentPath, fileName);
-    await mutate(buildFilesCacheKey(instanceName, currentPath));
+    await apiCreateEmptyFile(instanceName, project, currentPath, fileName);
+    await mutate(buildFilesCacheKey(instanceName, currentPath, project));
   };
 
   const createDirectory = async (currentPath: string, dirName: string) => {
-    await apiCreateDirectory(instanceName, currentPath, dirName);
-    await mutate(buildFilesCacheKey(instanceName, currentPath));
+    await apiCreateDirectory(instanceName, project, currentPath, dirName);
+    await mutate(buildFilesCacheKey(instanceName, currentPath, project));
   };
 
   const deleteFile = async (filePath: string) => {
-    await apiDeleteFile(instanceName, filePath);
-    await mutate(buildFilesCacheKey(instanceName, absPathParent(filePath)));
+    await apiDeleteFile(instanceName, project, filePath);
+    await mutate(buildFilesCacheKey(instanceName, absPathParent(filePath), project));
   };
 
   const downloadFile = (filePath: string) => {
-    apiDownloadFile(instanceName, filePath);
+    apiDownloadFile(instanceName, project, filePath);
   };
 
   const fetchFileContent = async (filePath: string) => {
-    return apiFetchFileContent(instanceName, filePath);
+    return apiFetchFileContent(instanceName, project, filePath);
   };
 
   const fetchFileRaw = async (filePath: string) => {
-    return apiFetchFileRaw(instanceName, filePath);
+    return apiFetchFileRaw(instanceName, project, filePath);
   };
 
   const saveFileContent = async (filePath: string, content: string, mode?: string) => {
-    await apiSaveFileContent(instanceName, filePath, content, mode);
-    await mutate(buildFilesCacheKey(instanceName, absPathParent(filePath)));
+    await apiSaveFileContent(instanceName, project, filePath, content, mode);
+    await mutate(buildFilesCacheKey(instanceName, absPathParent(filePath), project));
   };
 
   const moveFiles = async (
@@ -333,13 +349,13 @@ export function useFiles(instanceName: string, path: string) {
       refresh.add(absPathParent(s.sourcePath));
       refresh.add(dest);
       await moveRemoteFile({
-        fetchFileBlob: (p) => apiFetchFileBlob(instanceName, p),
+        fetchFileBlob: (p) => apiFetchFileBlob(instanceName, project, p),
         sourcePath: s.sourcePath,
         destParentPath: dest,
         fileName: s.fileName,
         uploadToParent: (parent, file, prog) =>
-          apiUploadFile(instanceName, parent, file, prog),
-        deleteFile: (p) => apiDeleteFile(instanceName, p),
+          apiUploadFile(instanceName, project, parent, file, prog),
+        deleteFile: (p) => apiDeleteFile(instanceName, project, p),
         onProgress: (phase, pct) =>
           onProgress?.(phase, pct, {
             index: i + 1,
@@ -349,24 +365,25 @@ export function useFiles(instanceName: string, path: string) {
       });
     }
     for (const p of refresh) {
-      await mutate(buildFilesCacheKey(instanceName, p));
+      await mutate(buildFilesCacheKey(instanceName, p, project));
     }
   };
 
   const listChildDirectories = useCallback(
     async (parentPath: string) =>
-      apiListChildDirectoryPaths(instanceName, parentPath),
-    [instanceName],
+      apiListChildDirectoryPaths(instanceName, project, parentPath),
+    [instanceName, project],
   );
 
   const probeInstancePathKind = useCallback(
-    async (absPath: string) => apiProbeInstancePathKind(instanceName, absPath),
-    [instanceName],
+    async (absPath: string) => apiProbeInstancePathKind(instanceName, project, absPath),
+    [instanceName, project],
   );
 
   const fetchDirectoryEntries = useCallback(
-    (dirPath: string) => fetchDirectoryEntriesForInstance(instanceName, dirPath),
-    [instanceName],
+    (dirPath: string) =>
+      fetchDirectoryEntriesForInstance(instanceName, project, dirPath),
+    [instanceName, project],
   );
 
   const renameEntry = async (fullPath: string, newBaseName: string) => {

--- a/app/(main)/instance/files/_lib/files.ts
+++ b/app/(main)/instance/files/_lib/files.ts
@@ -6,10 +6,22 @@ import {
   absPathParent,
 } from '../../../_lib/files/path';
 import { errorMessageFromResponse } from '../../_lib/incus-fetch-error';
+import { buildApiPath } from '@/app/_lib/url';
 
 export function getApiUrl(path: string) {
   if (typeof window === 'undefined') return path;
   return `${window.location.origin}${path}`;
+}
+
+function buildInstanceFilesPath(
+  instanceName: string,
+  filePath: string,
+  project?: string | null,
+) {
+  return buildApiPath(`/1.0/instances/${encodeURIComponent(instanceName)}/files`, {
+    project: project ?? null,
+    params: { path: filePath },
+  });
 }
 
 function postFileXhr(
@@ -61,15 +73,14 @@ function postFileXhr(
 
 export async function uploadFile(
   instanceName: string,
+  project: string | null | undefined,
   currentPath: string,
   file: File,
   onProgress?: (percent: number | null) => void,
 ) {
   const parentDir = normalizeAbsPath(currentPath);
   const filePath = joinAbsPath(parentDir, file.name);
-  const url = getApiUrl(
-    `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(filePath)}`,
-  );
+  const url = getApiUrl(buildInstanceFilesPath(instanceName, filePath, project));
   await postFileXhr(
     url,
     file,
@@ -93,49 +104,46 @@ export async function uploadFile(
 
 export async function createDirectory(
   instanceName: string,
+  project: string | null | undefined,
   currentPath: string,
   dirName: string,
 ) {
   const dirPath = joinAbsPath(currentPath, dirName);
-  const res = await fetch(
-    getApiUrl(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(dirPath)}`,
-    ),
-    {
-      method: 'POST',
-      headers: {
-        'X-Incus-uid': '0',
-        'X-Incus-gid': '0',
-        'X-Incus-mode': '0644',
-        'X-Incus-type': 'directory',
-      },
+  const res = await fetch(getApiUrl(buildInstanceFilesPath(instanceName, dirPath, project)), {
+    method: 'POST',
+    headers: {
+      'X-Incus-uid': '0',
+      'X-Incus-gid': '0',
+      'X-Incus-mode': '0644',
+      'X-Incus-type': 'directory',
     },
-  );
+  });
 
   if (!res.ok) {
     throw new Error(await errorMessageFromResponse(res));
   }
 }
 
-export async function deleteFile(instanceName: string, filePath: string) {
-  const res = await fetch(
-    getApiUrl(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(filePath)}`,
-    ),
-    {
-      method: 'DELETE',
-    },
-  );
+export async function deleteFile(
+  instanceName: string,
+  project: string | null | undefined,
+  filePath: string,
+) {
+  const res = await fetch(getApiUrl(buildInstanceFilesPath(instanceName, filePath, project)), {
+    method: 'DELETE',
+  });
 
   if (!res.ok) {
     throw new Error(await errorMessageFromResponse(res));
   }
 }
 
-export function downloadFile(instanceName: string, filePath: string) {
-  const url = getApiUrl(
-    `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(filePath)}`,
-  );
+export function downloadFile(
+  instanceName: string,
+  project: string | null | undefined,
+  filePath: string,
+) {
+  const url = getApiUrl(buildInstanceFilesPath(instanceName, filePath, project));
   const link = document.createElement('a');
   link.href = url;
   link.download = filePath.split('/').pop() || 'download';
@@ -144,8 +152,12 @@ export function downloadFile(instanceName: string, filePath: string) {
   document.body.removeChild(link);
 }
 
-export async function fetchFileContent(instanceName: string, filePath: string) {
-  const raw = await fetchFileRaw(instanceName, filePath);
+export async function fetchFileContent(
+  instanceName: string,
+  project: string | null | undefined,
+  filePath: string,
+) {
+  const raw = await fetchFileRaw(instanceName, project, filePath);
   const content = new TextDecoder('utf-8', { fatal: false }).decode(raw.buffer);
   return { content, mode: raw.mode };
 }
@@ -153,13 +165,10 @@ export async function fetchFileContent(instanceName: string, filePath: string) {
 /** Full file bytes for classification / binary handling (single GET). */
 export async function fetchFileRaw(
   instanceName: string,
+  project: string | null | undefined,
   filePath: string,
 ): Promise<{ buffer: ArrayBuffer; mode?: string }> {
-  const res = await fetch(
-    getApiUrl(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(filePath)}`,
-    ),
-  );
+  const res = await fetch(getApiUrl(buildInstanceFilesPath(instanceName, filePath, project)));
   if (!res.ok) {
     throw new Error(await errorMessageFromResponse(res));
   }
@@ -175,13 +184,10 @@ export async function fetchFileRaw(
 /** Same GET semantics as fetchFileRaw, but uses Blob (may reduce peak heap vs ArrayBuffer for large files). */
 export async function fetchFileBlob(
   instanceName: string,
+  project: string | null | undefined,
   filePath: string,
 ): Promise<{ blob: Blob; mode?: string }> {
-  const res = await fetch(
-    getApiUrl(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(filePath)}`,
-    ),
-  );
+  const res = await fetch(getApiUrl(buildInstanceFilesPath(instanceName, filePath, project)));
   if (!res.ok) {
     throw new Error(await errorMessageFromResponse(res));
   }
@@ -199,14 +205,11 @@ export async function fetchFileBlob(
  */
 export async function fetchSymlinkTargetRawPath(
   instanceName: string,
+  project: string | null | undefined,
   absPath: string,
 ): Promise<string | null> {
   const p = normalizeAbsPath(absPath);
-  const res = await fetch(
-    getApiUrl(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(p)}`,
-    ),
-  );
+  const res = await fetch(getApiUrl(buildInstanceFilesPath(instanceName, p, project)));
   if (!res.ok) return null;
   const ct = (res.headers.get('Content-Type') || '').toLowerCase();
   if (ct.includes('application/json')) return null;
@@ -220,20 +223,21 @@ const SYMLINK_PROBE_MAX_DEPTH = 12;
 /** Where to navigate after opening a symlink row: list this directory, optionally then open this file. */
 export async function getSymlinkResolvedNavTarget(
   instanceName: string,
+  project: string | null | undefined,
   linkAbsPath: string,
   depth = 0,
 ): Promise<{ directoryPath: string; fileBasename?: string }> {
   if (depth > SYMLINK_PROBE_MAX_DEPTH) {
     return { directoryPath: normalizeAbsPath(linkAbsPath) };
   }
-  const raw = await fetchSymlinkTargetRawPath(instanceName, linkAbsPath);
+  const raw = await fetchSymlinkTargetRawPath(instanceName, project, linkAbsPath);
   if (!raw) {
     return { directoryPath: normalizeAbsPath(linkAbsPath) };
   }
   const resolved = resolveSymlinkTarget(linkAbsPath, raw);
   let meta;
   try {
-    meta = await getFileMetadata(instanceName, resolved);
+    meta = await getFileMetadata(instanceName, project, resolved);
   } catch {
     return { directoryPath: resolved };
   }
@@ -242,7 +246,7 @@ export async function getSymlinkResolvedNavTarget(
     return { directoryPath: resolved };
   }
   if (t === 'symlink') {
-    return getSymlinkResolvedNavTarget(instanceName, resolved, depth + 1);
+    return getSymlinkResolvedNavTarget(instanceName, project, resolved, depth + 1);
   }
   if (t === 'file') {
     return {
@@ -255,27 +259,23 @@ export async function getSymlinkResolvedNavTarget(
 
 export async function saveFileContent(
   instanceName: string,
+  project: string | null | undefined,
   filePath: string,
   content: string,
   mode: string = '0644',
 ) {
-  const res = await fetch(
-    getApiUrl(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(filePath)}`,
-    ),
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/octet-stream',
-        'X-Incus-uid': '0',
-        'X-Incus-gid': '0',
-        'X-Incus-mode': mode,
-        'X-Incus-type': 'file',
-        'X-Incus-write': 'overwrite',
-      },
-      body: content,
+  const res = await fetch(getApiUrl(buildInstanceFilesPath(instanceName, filePath, project)), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'X-Incus-uid': '0',
+      'X-Incus-gid': '0',
+      'X-Incus-mode': mode,
+      'X-Incus-type': 'file',
+      'X-Incus-write': 'overwrite',
     },
-  );
+    body: content,
+  });
 
   if (!res.ok) {
     throw new Error(await errorMessageFromResponse(res));
@@ -284,22 +284,22 @@ export async function saveFileContent(
 
 export async function createEmptyFile(
   instanceName: string,
+  project: string | null | undefined,
   currentPath: string,
   fileName: string,
 ) {
   const filePath = joinAbsPath(currentPath, fileName);
-  await saveFileContent(instanceName, filePath, '', '0644');
+  await saveFileContent(instanceName, project, filePath, '', '0644');
 }
 
-export async function getFileMetadata(instanceName: string, filePath: string) {
-  const res = await fetch(
-    getApiUrl(
-      `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(filePath)}`,
-    ),
-    {
-      method: 'HEAD',
-    },
-  );
+export async function getFileMetadata(
+  instanceName: string,
+  project: string | null | undefined,
+  filePath: string,
+) {
+  const res = await fetch(getApiUrl(buildInstanceFilesPath(instanceName, filePath, project)), {
+    method: 'HEAD',
+  });
 
   if (!res.ok) {
     throw new Error(await errorMessageFromResponse(res));
@@ -317,11 +317,12 @@ export async function getFileMetadata(instanceName: string, filePath: string) {
 /** True if `path` exists on the instance and is a directory (HEAD + X-Incus-type). */
 export async function checkDirectoryExists(
   instanceName: string,
+  project: string | null | undefined,
   dirPath: string,
 ): Promise<boolean> {
   try {
     const p = normalizeAbsPath(dirPath);
-    const meta = await getFileMetadata(instanceName, p);
+    const meta = await getFileMetadata(instanceName, project, p);
     return (meta.type ?? '').toLowerCase() === 'directory';
   } catch {
     return false;
@@ -353,12 +354,11 @@ const DIRECTORY_HEAD_BATCH = 16;
 /** Immediate child directories of `parentDir` (HEAD each entry). */
 export async function listChildDirectoryPaths(
   instanceName: string,
+  project: string | null | undefined,
   parentDir: string,
 ): Promise<string[]> {
   const parent = normalizeAbsPath(parentDir);
-  const url = getApiUrl(
-    `/1.0/instances/${instanceName}/files?path=${encodeURIComponent(parent)}`,
-  );
+  const url = getApiUrl(buildInstanceFilesPath(instanceName, parent, project));
   const res = await fetch(url);
   if (!res.ok) return [];
   const names = parseSyncDirectoryListing(await res.text());
@@ -370,7 +370,7 @@ export async function listChildDirectoryPaths(
       slice.map(async (name) => {
         const full = joinAbsPath(parent, name);
         try {
-          const meta = await getFileMetadata(instanceName, full);
+          const meta = await getFileMetadata(instanceName, project, full);
           const mt = (meta.type ?? '').toLowerCase();
           if (mt === 'directory') return full;
           if (mt === 'symlink') return full;
@@ -391,27 +391,29 @@ export type InstancePathKind = 'directory' | 'file' | 'missing';
 
 export async function probeInstancePathKind(
   instanceName: string,
+  project: string | null | undefined,
   absPath: string,
 ): Promise<InstancePathKind> {
-  return probeInstancePathKindInner(instanceName, absPath, 0);
+  return probeInstancePathKindInner(instanceName, project, absPath, 0);
 }
 
 async function probeInstancePathKindInner(
   instanceName: string,
+  project: string | null | undefined,
   absPath: string,
   depth: number,
 ): Promise<InstancePathKind> {
   if (depth > SYMLINK_PROBE_MAX_DEPTH) return 'missing';
   try {
     const p = normalizeAbsPath(absPath);
-    const meta = await getFileMetadata(instanceName, p);
+    const meta = await getFileMetadata(instanceName, project, p);
     const t = (meta.type ?? '').toLowerCase();
     if (t === 'directory') return 'directory';
     if (t === 'symlink') {
-      const raw = await fetchSymlinkTargetRawPath(instanceName, p);
+      const raw = await fetchSymlinkTargetRawPath(instanceName, project, p);
       if (!raw) return 'directory';
       const resolved = resolveSymlinkTarget(p, raw);
-      return probeInstancePathKindInner(instanceName, resolved, depth + 1);
+      return probeInstancePathKindInner(instanceName, project, resolved, depth + 1);
     }
     if (t === 'file') return 'file';
     return 'missing';

--- a/app/(main)/instance/files/page.tsx
+++ b/app/(main)/instance/files/page.tsx
@@ -26,7 +26,7 @@ function getInstanceFilesHomePath(instance: Instance): string {
 export default function FilesPage() {
   const searchParams = useSearchParams();
   const urlName = searchParams.get('name');
-  const { instance, isLoading } = useInstanceContext();
+  const { instance, project, isLoading } = useInstanceContext();
 
   if (isLoading) {
     return <Spinner />;
@@ -41,19 +41,29 @@ export default function FilesPage() {
     return <Spinner />;
   }
 
-  return <Files key={urlName} instance={instance} instanceName={urlName} />;
+  return (
+    <Files
+      key={urlName}
+      instance={instance}
+      instanceName={urlName}
+      project={project}
+    />
+  );
 }
 
 function Files({
   instance,
   instanceName,
+  project,
 }: {
   instance: Instance;
   instanceName: string;
+  project: string | null;
 }) {
   const searchParams = useSearchParams();
   const [isRoutePending, startRouteTransition] = React.useTransition();
   const homePath = React.useMemo(() => getInstanceFilesHomePath(instance), [instance]);
+  const instanceProject = instance.project ?? project ?? null;
   const pathParam = searchParams.get('path');
   const currentPath = React.useMemo(() => {
     const raw = pathParam ?? homePath;
@@ -71,6 +81,9 @@ function Files({
 
       const params = new URLSearchParams();
       params.set('name', instanceName);
+      if (instanceProject) {
+        params.set('project', instanceProject);
+      }
       if (path === '/') {
         params.set('path', '/');
       } else if (path === homePath && homePath !== '/') {
@@ -84,7 +97,7 @@ function Files({
       const target = query ? `${currentPathname}?${query}` : currentPathname;
       window.history.pushState(null, '', target);
     });
-  }, [homePath, instanceName, startRouteTransition]);
+  }, [homePath, instanceName, instanceProject, startRouteTransition]);
 
   const {
     files,
@@ -106,7 +119,7 @@ function Files({
     probeInstancePathKind,
     fetchDirectoryEntries,
     requestMetadataForNames,
-  } = useFiles(instanceName, currentPath);
+  } = useFiles(instanceName, currentPath, instanceProject);
 
   return (
     <FileBrowser
@@ -128,7 +141,7 @@ function Files({
       fetchDirectoryEntries={fetchDirectoryEntries}
       requestMetadataForNames={requestMetadataForNames}
       resolveSymlinkNavTarget={(path) =>
-        getSymlinkResolvedNavTarget(instanceName, path)
+        getSymlinkResolvedNavTarget(instanceName, instanceProject, path)
       }
       onCreateEmptyFile={(name) => createEmptyFile(currentPath, name)}
       onCreateDirectory={(name) => createDirectory(currentPath, name)}

--- a/app/(main)/instance/layout.tsx
+++ b/app/(main)/instance/layout.tsx
@@ -46,7 +46,7 @@ import Link from 'next/link';
 
 function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
   const isClient = React.use(IsClientContext);
-  const { name, instance, isLoading, isError, mutate } = useInstanceContext();
+  const { name, project, instance, isLoading, isError, mutate } = useInstanceContext();
 
   const pathname = usePathname();
 
@@ -58,6 +58,15 @@ function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
   };
 
   const { label: formattedTab } = getTabFromPathname(pathname);
+  const instanceQuery = React.useMemo(() => {
+    if (!name) return undefined;
+
+    const query: Record<string, string> = { name };
+    if (project) {
+      query.project = project;
+    }
+    return query;
+  }, [name, project]);
 
   const renderContent = () => {
     if (!name) {
@@ -121,7 +130,14 @@ function InstanceLayoutContent({ children }: { children: React.ReactNode }) {
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>
                   <BreadcrumbLink asChild>
-                    <Link href={`/instance?name=${name}`}>{name}</Link>
+                    <Link
+                      href={{
+                        pathname: '/instance',
+                        query: instanceQuery,
+                      }}
+                    >
+                      {name}
+                    </Link>
                   </BreadcrumbLink>
                 </BreadcrumbItem>
                 <BreadcrumbSeparator />
@@ -300,7 +316,10 @@ function InstanceHeader({
         signal: abortController.signal,
       });
 
-      const nextKey = getInstanceCacheKey(updatedInstance.name);
+      const nextKey = getInstanceCacheKey(
+        updatedInstance.name,
+        updatedInstance.project ?? instance.project ?? null,
+      );
 
       if (nextKey) {
         await mutateCache(
@@ -531,7 +550,7 @@ const TABS = [
 
 function InstanceTabs() {
   const pathname = usePathname();
-  const { name: instanceName } = useInstanceContext();
+  const { name: instanceName, project } = useInstanceContext();
 
   // Determine current tab based on pathname
   // /instance -> dashboard
@@ -556,12 +575,20 @@ function InstanceTabs() {
             const targetPath =
               tab.value === 'dashboard' ? '/instance' : `/instance/${tab.value}`;
 
+            const query =
+              instanceName
+                ? {
+                    name: instanceName,
+                    ...(project ? { project } : {}),
+                  }
+                : undefined;
+
             return (
               <TabsTrigger key={tab.value} value={tab.value} asChild>
                 <Link
                   href={{
                     pathname: targetPath,
-                    query: instanceName ? { name: instanceName } : undefined,
+                    query,
                   }}
                 >
                   <tab.icon aria-hidden="true" className="mr-2 h-4 w-4" />

--- a/app/(main)/instances/_components/create.tsx
+++ b/app/(main)/instances/_components/create.tsx
@@ -62,7 +62,9 @@ function hasValidRootDisk(
 import GeneralConfiguration from '@/app/(main)/_components/general-configuration';
 import { useProfiles } from '@/app/(main)/_hooks/profiles';
 import { useStoragePools } from '@/app/(main)/_hooks/storagePools';
-import ProjectsContext from '@/app/(main)/_context/projects';
+import ProjectsContext, {
+  ALL_PROJECTS_VALUE,
+} from '@/app/(main)/_context/projects';
 import { useServerConfiguration } from '@/app/_hooks/server';
 import { Spinner } from 'ui-web/components/spinner';
 import { toast } from 'sonner';
@@ -116,7 +118,7 @@ const formSchema = z.object({
   source: sourceSchema,
 });
 export default function CreateInstance({ className }: { className?: string }) {
-  const { effectiveProject } = use(ProjectsContext);
+  const { currentProject, effectiveProject, projects } = use(ProjectsContext);
   const { resolvedTheme } = useTheme();
   const { data: server, isLoading: isLoadingServerConfiguration } =
     useServerConfiguration();
@@ -216,7 +218,18 @@ export default function CreateInstance({ className }: { className?: string }) {
   }, [server?.api_extensions]);
   const isBackupSupported =
     !isLoadingServerConfiguration && missingBackupExtensions.length === 0;
-  const resolvedTargetProject = effectiveProject ?? '';
+  const resolvedTargetProject = useMemo(() => {
+    if (effectiveProject) {
+      return effectiveProject;
+    }
+
+    if (currentProject !== ALL_PROJECTS_VALUE) {
+      return '';
+    }
+
+    const defaultProject = projects.find((project) => project.name === 'default');
+    return defaultProject?.name ?? projects[0]?.name ?? '';
+  }, [currentProject, effectiveProject, projects]);
 
   const resetSourceFields = () => {
     form.setValue('source.fingerprint', undefined, { shouldDirty: true });
@@ -696,8 +709,8 @@ export default function CreateInstance({ className }: { className?: string }) {
                         }}
                       />
                       <p className="text-muted-foreground text-sm">
-                        Upload an exported Incus backup archive to restore it as a
-                        new instance.
+                        Upload an exported backup archive to restore it as a new
+                        instance.
                       </p>
                       {backupFile ? (
                         <p className="text-sm font-medium">{backupFile.name}</p>

--- a/app/(main)/instances/_components/create.tsx
+++ b/app/(main)/instances/_components/create.tsx
@@ -433,6 +433,9 @@ export default function CreateInstance({ className }: { className?: string }) {
             source.type === 'backup'
           ) {
             form.setValue('source.type', source.type, { shouldValidate: true });
+            if (source.type === 'backup') {
+              setShowYamlEditor(false);
+            }
             if (source.type === 'image') {
               if (typeof source.fingerprint === 'string') {
                 form.setValue('source.fingerprint', source.fingerprint, {
@@ -559,9 +562,7 @@ export default function CreateInstance({ className }: { className?: string }) {
       );
     } finally {
       setIsSubmitting(false);
-      if (!isBackupMode) {
-        setImportProgress(null);
-      }
+      setImportProgress(null);
     }
   };
 

--- a/app/(main)/instances/_components/create.tsx
+++ b/app/(main)/instances/_components/create.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { Alert, AlertDescription, AlertTitle } from 'ui-web/components/alert';
 import { Button } from 'ui-web/components/button';
+import { Progress } from 'ui-web/components/progress';
 import {
   Dialog,
   DialogContent,
@@ -26,6 +28,7 @@ import {
   SelectValue,
 } from 'ui-web/components/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from 'ui-web/components/tabs';
+import { Input } from 'ui-web/components/input';
 import { useState, useMemo, use, useCallback, useRef } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -36,7 +39,10 @@ import ImageSelector, {
 import InstanceProperties from '@/app/(main)/instances/_components/properties';
 import InstanceDevices from './devices';
 import type { Device } from '@/app/(main)/instances/_lib/instances.d';
-import { createInstance } from '@/app/(main)/instances/_lib/instances';
+import {
+  createInstance,
+  importInstanceFromBackup,
+} from '@/app/(main)/instances/_lib/instances';
 import { toYaml, fromYaml } from '@/app/(main)/_lib/yaml';
 
 /**
@@ -55,19 +61,21 @@ function hasValidRootDisk(
 
 import GeneralConfiguration from '@/app/(main)/_components/general-configuration';
 import { useProfiles } from '@/app/(main)/_hooks/profiles';
+import { useStoragePools } from '@/app/(main)/_hooks/storagePools';
 import ProjectsContext from '@/app/(main)/_context/projects';
+import { useServerConfiguration } from '@/app/_hooks/server';
 import { Spinner } from 'ui-web/components/spinner';
 import { toast } from 'sonner';
 import Editor, { OnMount } from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
 import { mutate } from 'swr';
 import type * as Monaco from 'monaco-editor';
-import { CodeXmlIcon } from 'lucide-react';
+import { AlertCircleIcon, CodeXmlIcon, UploadIcon } from 'lucide-react';
 import { cn } from 'ui-web/lib/utils';
 
 const sourceSchema = z
   .object({
-    type: z.enum(['image', 'none']),
+    type: z.enum(['image', 'none', 'backup']),
     fingerprint: z.string().optional(),
     alias: z.string().optional(),
     server: z.string().optional(),
@@ -77,6 +85,9 @@ const sourceSchema = z
   .refine(
     (data) => {
       if (data.type === 'none') {
+        return true;
+      }
+      if (data.type === 'backup') {
         return true;
       }
       if (data.fingerprint) {
@@ -107,10 +118,18 @@ const formSchema = z.object({
 export default function CreateInstance({ className }: { className?: string }) {
   const { effectiveProject } = use(ProjectsContext);
   const { resolvedTheme } = useTheme();
+  const { data: server, isLoading: isLoadingServerConfiguration } =
+    useServerConfiguration();
+  const { data: storagePools, isLoading: isLoadingStoragePools } =
+    useStoragePools();
   const [profilesSelected, setProfilesSelected] = useState<string[]>(['default']);
   const [instanceType, setInstanceType] = useState<'virtual-machine' | 'container'>('container');
   const [devices, setDevices] = useState<Record<string, Device>>({});
   const [config, setConfig] = useState<Record<string, string>>({});
+  const [backupFile, setBackupFile] = useState<File | null>(null);
+  const [backupFileInputKey, setBackupFileInputKey] = useState(0);
+  const [backupPoolName, setBackupPoolName] = useState('');
+  const [importProgress, setImportProgress] = useState<number | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [yamlError, setYamlError] = useState<string | null>(null);
@@ -177,8 +196,27 @@ export default function CreateInstance({ className }: { className?: string }) {
     control: form.control,
     name: 'source.type',
   });
+  const isBackupMode = sourceType === 'backup';
   const selectingImage = sourceType === 'image' && currentTab === 'source';
   const [selectedImage, setSelectedImage] = useState<SelectableImage | null>(null);
+  const missingBackupExtensions = useMemo(() => {
+    const requiredExtensions = [
+      'container_backup',
+      'container_backup_override_pool',
+      'backup_override_name',
+    ];
+
+    if (!server?.api_extensions) {
+      return [];
+    }
+
+    return requiredExtensions.filter(
+      (extension) => !server.api_extensions.includes(extension),
+    );
+  }, [server?.api_extensions]);
+  const isBackupSupported =
+    !isLoadingServerConfiguration && missingBackupExtensions.length === 0;
+  const resolvedTargetProject = effectiveProject ?? '';
 
   const resetSourceFields = () => {
     form.setValue('source.fingerprint', undefined, { shouldDirty: true });
@@ -186,6 +224,12 @@ export default function CreateInstance({ className }: { className?: string }) {
     form.setValue('source.server', undefined, { shouldDirty: true });
     form.setValue('source.alias', undefined, { shouldDirty: true });
     form.setValue('source.protocol', undefined, { shouldDirty: true });
+  };
+  const resetBackupFields = () => {
+    setBackupFile(null);
+    setBackupFileInputKey((current) => current + 1);
+    setBackupPoolName('');
+    setImportProgress(null);
   };
 
   const handleImageSelect = (image: SelectableImage) => {
@@ -218,8 +262,11 @@ export default function CreateInstance({ className }: { className?: string }) {
   // Watch form changes to re-evaluate validity
   useWatch({ control: form.control });
   const rootDiskValid = useMemo(
-    () => hasValidRootDisk(devices, inheritedDevices),
-    [devices, inheritedDevices],
+    () =>
+      isBackupMode
+        ? backupPoolName.trim().length > 0
+        : hasValidRootDisk(devices, inheritedDevices),
+    [backupPoolName, devices, inheritedDevices, isBackupMode],
   );
 
   const isFormValid = useMemo(() => {
@@ -227,14 +274,33 @@ export default function CreateInstance({ className }: { className?: string }) {
     const formState = form.formState;
     if (!formState.isValid) return false;
 
+    if (!resolvedTargetProject) return false;
+
     // Check root disk
     if (!rootDiskValid) return false;
 
     // Check YAML error
     if (yamlError) return false;
 
+    if (isBackupMode) {
+      if (!backupFile) return false;
+      if (!backupPoolName.trim()) return false;
+      if (isLoadingServerConfiguration) return false;
+      if (!isBackupSupported) return false;
+    }
+
     return true;
-  }, [form.formState, rootDiskValid, yamlError]);
+  }, [
+    backupFile,
+    backupPoolName,
+    form.formState,
+    isBackupMode,
+    isBackupSupported,
+    resolvedTargetProject,
+    rootDiskValid,
+    yamlError,
+    isLoadingServerConfiguration,
+  ]);
 
   // Build the instance payload
   const buildPayload = useCallback(() => {
@@ -299,13 +365,15 @@ export default function CreateInstance({ className }: { className?: string }) {
   const getDialogContentClassName = useCallback(() => {
     return cn(
       'flex max-h-[90vh] w-full flex-col transition-all duration-200',
-      selectingImage
+      isBackupMode
+        ? 'sm:max-w-xl'
+        : selectingImage
         ? 'sm:max-w-5xl'
         : currentTab === 'devices' || currentTab === 'general' || showYamlEditor
           ? 'h-[90vh] sm:max-w-6xl'
           : 'sm:max-w-xl',
     );
-  }, [currentTab, selectingImage, showYamlEditor]);
+  }, [currentTab, isBackupMode, selectingImage, showYamlEditor]);
 
   // Handle Monaco editor mount
   const handleEditorMount: OnMount = useCallback((editor) => {
@@ -346,7 +414,11 @@ export default function CreateInstance({ className }: { className?: string }) {
         }
         if (parsed.source && typeof parsed.source === 'object') {
           const source = parsed.source as Record<string, unknown>;
-          if (source.type === 'none' || source.type === 'image') {
+          if (
+            source.type === 'none' ||
+            source.type === 'image' ||
+            source.type === 'backup'
+          ) {
             form.setValue('source.type', source.type, { shouldValidate: true });
             if (source.type === 'image') {
               if (typeof source.fingerprint === 'string') {
@@ -388,21 +460,66 @@ export default function CreateInstance({ className }: { className?: string }) {
       return;
     }
 
+    if (!resolvedTargetProject) {
+      toast.error('Select a target project before creating or importing an instance');
+      return;
+    }
+
+    if (isBackupMode) {
+      if (!backupFile) {
+        toast.error('Select a backup archive to continue');
+        return;
+      }
+
+      if (!backupPoolName.trim()) {
+        toast.error('Select a storage pool to continue');
+        return;
+      }
+
+      if (isLoadingServerConfiguration) {
+        toast.error('Checking server backup import support');
+        return;
+      }
+
+      if (!isBackupSupported) {
+        toast.error('Backup import is not supported by this server');
+        return;
+      }
+    }
+
+    const selectedBackupFile = backupFile;
+
     if (!rootDiskValid) {
-      toast.error('A valid root disk with a storage pool is required');
-      setCurrentTab('devices');
+      toast.error(
+        isBackupMode
+          ? 'A target storage pool is required'
+          : 'A valid root disk with a storage pool is required',
+      );
+      if (!isBackupMode) {
+        setCurrentTab('devices');
+      }
       return;
     }
 
     setIsSubmitting(true);
     try {
-      const payload = buildPayload();
-      const result = await createInstance(payload, effectiveProject);
+      const result = isBackupMode
+        ? await importInstanceFromBackup(selectedBackupFile as File, {
+            name: form.getValues().name,
+            pool: backupPoolName,
+            project: resolvedTargetProject,
+            onProgress: setImportProgress,
+          })
+        : await createInstance(buildPayload(), resolvedTargetProject);
 
       if (result.error) {
         toast.error(result.error);
       } else {
-        toast.success(`Instance "${form.getValues().name}" creation started`);
+        toast.success(
+          isBackupMode
+            ? `Backup import for "${form.getValues().name}" started`
+            : `Instance "${form.getValues().name}" creation started`,
+        );
         // Invalidate the instances list
         mutate((key) => typeof key === 'string' && key.startsWith('/1.0/instances'));
         setDialogOpen(false);
@@ -411,6 +528,7 @@ export default function CreateInstance({ className }: { className?: string }) {
         setDevices({});
         setConfig({});
         setSelectedImage(null);
+        resetBackupFields();
         setProfilesSelected(['default']);
         setInstanceType('container');
         setYamlContent('');
@@ -419,9 +537,18 @@ export default function CreateInstance({ className }: { className?: string }) {
         setShowYamlEditor(false);
       }
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to create instance');
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : isBackupMode
+            ? 'Failed to import backup archive'
+            : 'Failed to create instance',
+      );
     } finally {
       setIsSubmitting(false);
+      if (!isBackupMode) {
+        setImportProgress(null);
+      }
     }
   };
 
@@ -431,6 +558,9 @@ export default function CreateInstance({ className }: { className?: string }) {
         open={dialogOpen}
         onOpenChange={(open) => {
           if (!isSubmitting) {
+            if (!open) {
+              resetBackupFields();
+            }
             setDialogOpen(open);
           }
         }}
@@ -484,43 +614,12 @@ export default function CreateInstance({ className }: { className?: string }) {
                     />
                   </div>
                 </div>
-                <Tabs
-                  className={`flex min-h-0 w-full flex-1 flex-col ${
-                    showYamlEditor ? 'absolute inset-0 pointer-events-none invisible' : ''
-                  }`}
-                  value={currentTab}
-                  onValueChange={handleTabChange}
-                  aria-hidden={showYamlEditor}
-                >
-                  <TabsList className="w-full shrink-0" defaultValue="properties">
-                    <TabsTrigger type="button" value="properties">
-                      Properties
-                    </TabsTrigger>
-                    <TabsTrigger type="button" value="source">
-                      Source
-                    </TabsTrigger>
-                    <TabsTrigger type="button" value="devices">
-                      Devices
-                    </TabsTrigger>
-                    <TabsTrigger type="button" value="general">
-                      Configuration
-                    </TabsTrigger>
-                  </TabsList>
-                  <TabsContent
-                    value="properties"
-                    className="mt-0 min-h-0 flex-1 overflow-auto px-1 data-[state=active]:flex data-[state=active]:flex-col"
-                  >
-                    <InstanceProperties
-                      form={form}
-                      profilesSelected={profilesSelected}
-                      setProfilesSelected={setProfilesSelected}
-                      instanceType={instanceType}
-                      setInstanceType={setInstanceType}
-                    />
-                  </TabsContent>
-                  <TabsContent
-                    value="source"
-                    className="mt-0 min-h-0 flex-1 overflow-auto data-[state=active]:flex data-[state=active]:flex-col"
+                {isBackupMode ? (
+                  <div
+                    className={`flex min-h-0 w-full flex-1 flex-col gap-4 overflow-auto ${
+                      showYamlEditor ? 'absolute inset-0 pointer-events-none invisible' : ''
+                    }`}
+                    aria-hidden={showYamlEditor}
                   >
                     <FormField
                       control={form.control}
@@ -532,6 +631,15 @@ export default function CreateInstance({ className }: { className?: string }) {
                             <Select
                               onValueChange={(value) => {
                                 field.onChange(value);
+                                if (value === 'backup') {
+                                  setSelectedImage(null);
+                                  resetSourceFields();
+                                  setShowYamlEditor(false);
+                                  setCurrentTab('source');
+                                  return;
+                                }
+
+                                resetBackupFields();
                                 if (value === 'none') {
                                   setSelectedImage(null);
                                   resetSourceFields();
@@ -545,6 +653,7 @@ export default function CreateInstance({ className }: { className?: string }) {
                               <SelectContent>
                                 <SelectItem value="image">Image</SelectItem>
                                 <SelectItem value="none">None</SelectItem>
+                                <SelectItem value="backup">Backup Archive</SelectItem>
                               </SelectContent>
                             </Select>
                           </FormControl>
@@ -552,39 +661,202 @@ export default function CreateInstance({ className }: { className?: string }) {
                         </FormItem>
                       )}
                     />
-                    {selectingImage ? (
-                      <ImageSelector
-                        selectedImage={selectedImage}
-                        onSelect={handleImageSelect}
-                        instanceType={instanceType}
-                      />
+                    {!isLoadingServerConfiguration && !isBackupSupported ? (
+                      <Alert variant="destructive">
+                        <AlertCircleIcon className="size-4" />
+                        <AlertTitle>Backup import is unavailable</AlertTitle>
+                        <AlertDescription>
+                          This server is missing the required Incus API extensions:{' '}
+                          {missingBackupExtensions.join(', ')}.
+                        </AlertDescription>
+                      </Alert>
                     ) : null}
-                  </TabsContent>
-                  <TabsContent
-                    value="devices"
-                    className="mt-0 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
-                  >
-                    <InstanceDevices
-                      profiles={profilesSelected}
-                      devices={devices}
-                      onDevicesChange={setDevices}
-                      instanceType={instanceType}
+                    <FormField
+                      control={form.control}
+                      name="name"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Instance Name</FormLabel>
+                          <FormControl>
+                            <Input placeholder="my-instance" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
                     />
-                  </TabsContent>
-                  <TabsContent
-                    value="general"
-                    className="mt-0 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
+                    <div className="grid gap-2">
+                      <FormLabel htmlFor="backup-file">Backup Archive</FormLabel>
+                      <Input
+                        key={backupFileInputKey}
+                        id="backup-file"
+                        type="file"
+                        accept=".tar.gz,.tgz,.tar,.tar.xz,.tar.zst,.tar.bz2,application/gzip,application/x-gzip,application/x-tar"
+                        onChange={(event) => {
+                          setBackupFile(event.target.files?.[0] ?? null);
+                        }}
+                      />
+                      <p className="text-muted-foreground text-sm">
+                        Upload an exported Incus backup archive to restore it as a
+                        new instance.
+                      </p>
+                      {backupFile ? (
+                        <p className="text-sm font-medium">{backupFile.name}</p>
+                      ) : null}
+                      {isSubmitting && backupFile ? (
+                        <div className="mt-2 grid gap-1.5">
+                          <div className="flex items-center justify-between text-sm">
+                            <span className="text-muted-foreground">
+                              Uploading backup archive
+                            </span>
+                            <span className="font-medium">
+                              {importProgress !== null ? `${importProgress}%` : 'Starting...'}
+                            </span>
+                          </div>
+                          <Progress value={importProgress ?? 0} />
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="grid gap-2">
+                      <FormLabel>Root Storage Pool</FormLabel>
+                      <Select
+                        value={backupPoolName}
+                        onValueChange={setBackupPoolName}
+                        disabled={isLoadingStoragePools || !storagePools?.length}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue
+                            placeholder={
+                              isLoadingStoragePools
+                                ? 'Loading storage pools...'
+                                : 'Select a storage pool'
+                            }
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {storagePools?.map((pool) => (
+                            <SelectItem key={pool.name} value={pool.name}>
+                              {pool.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <p className="text-muted-foreground text-sm">
+                        Choose the target pool for the restored instance root disk.
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <Tabs
+                    className={`flex min-h-0 w-full flex-1 flex-col ${
+                      showYamlEditor ? 'absolute inset-0 pointer-events-none invisible' : ''
+                    }`}
+                    value={currentTab}
+                    onValueChange={handleTabChange}
+                    aria-hidden={showYamlEditor}
                   >
-                    <div className="min-h-0 min-w-0 flex-1">
-                      <GeneralConfiguration
-                        config={config}
-                        expandedConfig={memoizedExpandedConfig}
-                        onConfigChange={setConfig}
+                    <TabsList className="w-full shrink-0" defaultValue="properties">
+                      <TabsTrigger type="button" value="properties">
+                        Properties
+                      </TabsTrigger>
+                      <TabsTrigger type="button" value="source">
+                        Source
+                      </TabsTrigger>
+                      <TabsTrigger type="button" value="devices">
+                        Devices
+                      </TabsTrigger>
+                      <TabsTrigger type="button" value="general">
+                        Configuration
+                      </TabsTrigger>
+                    </TabsList>
+                    <TabsContent
+                      value="properties"
+                      className="mt-0 min-h-0 flex-1 overflow-auto px-1 data-[state=active]:flex data-[state=active]:flex-col"
+                    >
+                      <InstanceProperties
+                        form={form}
+                        profilesSelected={profilesSelected}
+                        setProfilesSelected={setProfilesSelected}
+                        instanceType={instanceType}
+                        setInstanceType={setInstanceType}
+                      />
+                    </TabsContent>
+                    <TabsContent
+                      value="source"
+                      className="mt-0 min-h-0 flex-1 overflow-auto data-[state=active]:flex data-[state=active]:flex-col"
+                    >
+                      <FormField
+                        control={form.control}
+                        name="source.type"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Source Type</FormLabel>
+                            <FormControl>
+                              <Select
+                                onValueChange={(value) => {
+                                  field.onChange(value);
+                                  if (value === 'none') {
+                                    setSelectedImage(null);
+                                    resetSourceFields();
+                                    resetBackupFields();
+                                  } else if (value === 'backup') {
+                                    setSelectedImage(null);
+                                    resetSourceFields();
+                                    setShowYamlEditor(false);
+                                    setCurrentTab('source');
+                                  } else {
+                                    resetBackupFields();
+                                  }
+                                }}
+                                value={field.value}
+                              >
+                                <SelectTrigger className="w-full">
+                                  <SelectValue placeholder="Select source type" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="image">Image</SelectItem>
+                                  <SelectItem value="none">None</SelectItem>
+                                  <SelectItem value="backup">Backup Archive</SelectItem>
+                                </SelectContent>
+                              </Select>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      {selectingImage ? (
+                        <ImageSelector
+                          selectedImage={selectedImage}
+                          onSelect={handleImageSelect}
+                          instanceType={instanceType}
+                        />
+                      ) : null}
+                    </TabsContent>
+                    <TabsContent
+                      value="devices"
+                      className="mt-0 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
+                    >
+                      <InstanceDevices
+                        profiles={profilesSelected}
+                        devices={devices}
+                        onDevicesChange={setDevices}
                         instanceType={instanceType}
                       />
-                    </div>
-                  </TabsContent>
-                </Tabs>
+                    </TabsContent>
+                    <TabsContent
+                      value="general"
+                      className="mt-0 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col"
+                    >
+                      <div className="min-h-0 min-w-0 flex-1">
+                        <GeneralConfiguration
+                          config={config}
+                          expandedConfig={memoizedExpandedConfig}
+                          onConfigChange={setConfig}
+                          instanceType={instanceType}
+                        />
+                      </div>
+                    </TabsContent>
+                  </Tabs>
+                )}
               </div>
               <DialogFooter className="shrink-0">
                 <div className="flex w-full items-center justify-between">
@@ -592,6 +864,7 @@ export default function CreateInstance({ className }: { className?: string }) {
                     type="button"
                     variant="outline"
                     onClick={toggleYamlEditor}
+                    disabled={isBackupMode}
                   >
                     <CodeXmlIcon className="mr-2 size-4" />
                     {showYamlEditor ? 'Back to Wizard' : 'Edit YAML'}
@@ -604,10 +877,13 @@ export default function CreateInstance({ className }: { className?: string }) {
                     {isSubmitting ? (
                       <>
                         <Spinner className="mr-2 h-4 w-4" />
-                        Creating...
+                        {isBackupMode ? 'Importing...' : 'Creating...'}
                       </>
                     ) : (
-                      'Create Instance'
+                      <>
+                        {isBackupMode ? <UploadIcon className="mr-2 size-4" /> : null}
+                        {isBackupMode ? 'Import Backup' : 'Create Instance'}
+                      </>
                     )}
                   </Button>
                 </div>

--- a/app/(main)/instances/_lib/instances.d.ts
+++ b/app/(main)/instances/_lib/instances.d.ts
@@ -86,7 +86,7 @@ export interface CreateInstanceBody {
   description?: string;
   ephemeral?: boolean;
   source: {
-    type: 'image' | 'none';
+    type: 'image' | 'none' | 'backup';
     fingerprint?: string;
     alias?: string;
     server?: string;

--- a/app/(main)/instances/_lib/instances.ts
+++ b/app/(main)/instances/_lib/instances.ts
@@ -91,3 +91,92 @@ export async function createInstance(
     return { error: message };
   }
 }
+
+function importInstanceFromBackupXhr(
+  url: string,
+  backupFile: File,
+  headers: Record<string, string>,
+  onProgress?: (percent: number | null) => void,
+): Promise<{ operation?: string; error?: string }> {
+  return new Promise((resolve) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', url);
+
+    for (const [key, value] of Object.entries(headers)) {
+      xhr.setRequestHeader(key, value);
+    }
+
+    xhr.responseType = 'text';
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable && event.total > 0) {
+        onProgress?.(Math.round((event.loaded / event.total) * 100));
+      } else {
+        onProgress?.(null);
+      }
+    };
+    xhr.onerror = () => {
+      onProgress?.(null);
+      resolve({ error: 'Network error' });
+    };
+    xhr.onload = () => {
+      onProgress?.(100);
+
+      let data: Record<string, unknown> = {};
+      try {
+        data = xhr.responseText ? (JSON.parse(xhr.responseText) as Record<string, unknown>) : {};
+      } catch {
+        data = {};
+      }
+
+      if (xhr.status < 200 || xhr.status >= 300) {
+        resolve({
+          error:
+            (data.error as string) ||
+            `HTTP ${xhr.status}: ${xhr.statusText}`,
+        });
+        return;
+      }
+
+      if (data.type === 'error') {
+        resolve({
+          error: (data.error as string) || 'Failed to import backup archive',
+        });
+        return;
+      }
+
+      resolve({ operation: data.operation as string | undefined });
+    };
+
+    xhr.send(backupFile);
+  });
+}
+
+/**
+ * Import a new instance from a backup archive via POST /1.0/instances.
+ */
+export async function importInstanceFromBackup(
+  backupFile: File,
+  options: {
+    name: string;
+    pool: string;
+    project: string | null;
+    onProgress?: (percent: number | null) => void;
+  },
+): Promise<{ operation?: string; error?: string }> {
+  const params = new URLSearchParams();
+  if (options.project && options.project !== 'all') {
+    params.set('project', options.project);
+  }
+
+  const url = `/1.0/instances${params.toString() ? `?${params.toString()}` : ''}`;
+  return importInstanceFromBackupXhr(
+    url,
+    backupFile,
+    {
+      'Content-Type': 'application/octet-stream',
+      'X-Incus-name': options.name,
+      'X-Incus-pool': options.pool,
+    },
+    options.onProgress,
+  );
+}

--- a/app/(main)/instances/page.tsx
+++ b/app/(main)/instances/page.tsx
@@ -148,11 +148,15 @@ export default function Instances() {
         accessorKey: 'name',
         cell: ({ row }: { row: Row<object> }) => {
           const instance = row.original as Instance;
+          const query: Record<string, string> = {
+            name: instance.name,
+            project: instance.project ?? 'default',
+          };
           return (
             <Link
               href={{
                 pathname: '/instance',
-                query: { name: instance.name },
+                query,
               }}
               className="text-left font-medium text-primary underline focus:outline-none cursor-pointer"
               onClick={(event) => {


### PR DESCRIPTION
Allow creating instances from a backup import, and correct project respect bugs.
The "Backup Archive" source type can now be selected in the instance creation screen:
<img width="545" height="186" alt="image" src="https://github.com/user-attachments/assets/d9ad4b86-5be3-4792-ad95-616cac12cc48" />
When selected, options for setting the name & pool, along with the file upload for the archive are displayed
<img width="581" height="525" alt="image" src="https://github.com/user-attachments/assets/e68a4f64-a2e7-428b-83c8-c8e1caa53639" />